### PR TITLE
[BUGFIX] Avoid empty mountpoint parameter in URL when building the queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+* Avoid empty mountpoint parameter in URL when building the queue
 
 ### Deprecated
 #### Classes

--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -111,7 +111,7 @@ class ConfigurationService
                 $res[$key]['origin'] = 'pagets';
 
                 $url = '?id=' . $pageId;
-                $url .= is_string($mountPoint) ? '&MP=' . $mountPoint : '';
+                $url .= $mountPoint !== '' ? '&MP=' . $mountPoint : '';
                 $res[$key]['URLs'] = $this->getUrlService()->compileUrls($res[$key]['paramExpanded'], [$url], $maxUrlsToCompile);
             }
         }

--- a/Tests/Unit/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/Service/ConfigurationServiceTest.php
@@ -93,7 +93,7 @@ class ConfigurationServiceTest extends UnitTestCase
                 'mountPoint' => '',
                 'expected' => [],
             ],
-            'PageTSConfig with mountPoint false' => [
+            'PageTSConfig with empty mountPoint returning no URLs' => [
                 'pageTSConfig' => [
                     'tx_crawler.' => [
                         'crawlerCfg.' => [
@@ -127,7 +127,46 @@ class ConfigurationServiceTest extends UnitTestCase
                     ],
                 ],
             ],
-            'PageTSConfig with mountPoint string' => [
+            'PageTSConfig with empty mountPoint returning URLs' => [
+                'pageTSConfig' => [
+                    'tx_crawler.' => [
+                        'crawlerCfg.' => [
+                            'paramSets.' => [
+                                'myConfigurationKeyName' => '&S=CRAWL&L=[0-1]',
+                                'myConfigurationKeyName.' => [
+                                    'pidsOnly' => '1',
+                                    'procInstrFilter' => 'tx_indexedsearch_reindex',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'pageId' => 1,
+                'mountPoint' => '',
+                'expected' => [
+                    'myConfigurationKeyName' => [
+                        'subCfg' => [
+                            'pidsOnly' => '1',
+                            'procInstrFilter' => 'tx_indexedsearch_reindex',
+                            'key' => 'myConfigurationKeyName',
+                        ],
+                        'paramParsed' => [
+                            'S' => 'CRAWL',
+                            'L' => '[0-1]',
+                        ],
+                        'paramExpanded' => [
+                            'S' => ['CRAWL'],
+                            'L' => [0, 1],
+                        ],
+                        'origin' => 'pagets',
+                        'URLs' => [
+                            '?id=1&L=0&S=CRAWL',
+                            '?id=1&L=1&S=CRAWL',
+                        ],
+                    ],
+                ],
+            ],
+            'PageTSConfig with mountPoint given' => [
                 'pageTSConfig' => [
                     'tx_crawler.' => [
                         'crawlerCfg.' => [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -854,11 +854,6 @@ parameters:
 			path: Classes/Service/ConfigurationService.php
 
 		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: Classes/Service/ConfigurationService.php
-
-		-
 			message: "#^Method AOE\\\\Crawler\\\\Service\\\\ConfigurationService\\:\\:addValuesInRange\\(\\) has parameter \\$parameter with no typehint specified\\.$#"
 			count: 1
 			path: Classes/Service/ConfigurationService.php


### PR DESCRIPTION
Resolves: #781

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
