### PR TITLE
[TASK] Remove TCA configuration showRecordFieldList

### DIFF
--- a/Configuration/TCA/tx_crawler_configuration.php
+++ b/Configuration/TCA/tx_crawler_configuration.php
@@ -20,9 +20,6 @@ return [
             'default' => 'tx-crawler',
         ],
     ],
-    'interface' => [
-        'showRecordFieldList' => 'hidden,name,force_ssl,processing_instruction_filter,processing_instruction_parameters_ts,configuration,base_url,pidsonly,begroups,exclude',
-    ],
     'columns' => [
         'hidden' => [
             'exclude' => true,


### PR DESCRIPTION
## Description

The TCA configuration `showRecordFieldList` inside the section `interface` is not evaluated anymore and all occurrences have been removed.
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Feature-88901-RenderAllFieldsInElementInformationController.html

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
