### PR TITLE
[BUGFIX] Switch back to fetch() instead of fetchAssociative to support legacy TYPO3 installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Removes QueueRepository from FrontendUserAuthenticator Middleware, to ensure FE plugins can be rendered
 * PHP 8.0 compatibility problems. Undefined indexes resolved
 * Change requests to write to Header to ensure StaticFileCache is working
+* Switched back to fetch() instead of fetchAssociative() to keep support for legacy TYPO3 installations
 
 ### Deprecated
 #### Classes

--- a/Classes/Api/CrawlerApi.php
+++ b/Classes/Api/CrawlerApi.php
@@ -206,7 +206,7 @@ class CrawlerApi
             );
         }
 
-        $row = $query->execute()->fetchAssociative(0);
+        $row = $query->execute()->fetch(0);
         if ($row['latest']) {
             $res = $row['latest'];
         } else {

--- a/Classes/Backend/RequestForm/LogRequestForm.php
+++ b/Classes/Backend/RequestForm/LogRequestForm.php
@@ -146,7 +146,7 @@ final class LogRequestForm extends AbstractRequestForm implements RequestFormInt
                         $this->queryBuilder->expr()->eq('qid', $this->queryBuilder->createNamedParameter($queueId))
                     )
                     ->execute()
-                    ->fetchAssociative();
+                    ->fetch();
 
                 // Explode values
                 $q_entry['parameters'] = $this->jsonCompatibilityConverter->convert($q_entry['parameters']);

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -640,7 +640,7 @@ class CrawlerController implements LoggerAwareInterface
                 ->andWhere('exec_time = 0')
                 ->andWhere('process_scheduled > 0');
         }
-        $queueRec = $queryBuilder->execute()->fetchAssociative();
+        $queueRec = $queryBuilder->execute()->fetch();
 
         if (! is_array($queueRec)) {
             return;

--- a/Classes/Domain/Repository/ConfigurationRepository.php
+++ b/Classes/Domain/Repository/ConfigurationRepository.php
@@ -44,7 +44,7 @@ class ConfigurationRepository extends Repository
             ->from(self::TABLE_NAME)
             ->execute();
 
-        while ($row = $statement->fetchAssociative()) {
+        while ($row = $statement->fetch()) {
             $records[] = $row;
         }
 

--- a/Classes/Domain/Repository/ProcessRepository.php
+++ b/Classes/Domain/Repository/ProcessRepository.php
@@ -84,7 +84,7 @@ class ProcessRepository extends Repository
             ->orderBy('ttl', 'DESC')
             ->execute();
 
-        while ($row = $statement->fetchAssociative()) {
+        while ($row = $statement->fetch()) {
             $process = GeneralUtility::makeInstance(Process::class);
             $process->setProcessId($row['process_id']);
             $process->setActive($row['active']);
@@ -110,7 +110,7 @@ class ProcessRepository extends Repository
             ->from(self::TABLE_NAME)
             ->where(
                 $queryBuilder->expr()->eq('process_id', $queryBuilder->createNamedParameter($processId, PDO::PARAM_STR))
-            )->execute()->fetchAssociative(0);
+            )->execute()->fetch(0);
     }
 
     public function findAllActive(): ProcessCollection
@@ -129,7 +129,7 @@ class ProcessRepository extends Repository
             ->orderBy('ttl', 'DESC')
             ->execute();
 
-        while ($row = $statement->fetchAssociative()) {
+        while ($row = $statement->fetch()) {
             $process = new Process();
             $process->setProcessId($row['process_id']);
             $process->setActive($row['active']);
@@ -188,7 +188,7 @@ class ProcessRepository extends Repository
             )
             ->execute();
 
-        while ($row = $statement->fetchAssociative()) {
+        while ($row = $statement->fetch()) {
             $activeProcesses[] = $row;
         }
 

--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -237,7 +237,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
             ->execute();
 
         $setIds = [];
-        while ($row = $statement->fetchAssociative()) {
+        while ($row = $statement->fetch()) {
             $setIds[] = intval($row['set_id']);
         }
 
@@ -265,7 +265,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
                 ->groupBy('configuration')
                 ->execute();
 
-            while ($row = $statement->fetchAssociative()) {
+            while ($row = $statement->fetch()) {
                 $totals[$row['configuration']] = $row['c'];
             }
         }
@@ -289,7 +289,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
             ->execute();
 
         $rows = [];
-        while ($row = $statement->fetchAssociative()) {
+        while ($row = $statement->fetch()) {
             $rows[] = $row['exec_time'];
         }
 
@@ -312,7 +312,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
             ->execute();
 
         $rows = [];
-        while (($row = $statement->fetchAssociative()) !== false) {
+        while (($row = $statement->fetch()) !== false) {
             $rows[] = $row;
         }
 
@@ -343,7 +343,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
             ->execute();
 
         $rows = [];
-        while ($row = $statement->fetchAssociative()) {
+        while ($row = $statement->fetch()) {
             $rows[$row['process_id_completed']] = $row;
         }
 
@@ -416,7 +416,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
             ->execute();
 
         $rows = [];
-        while ($row = $statement->fetchAssociative()) {
+        while ($row = $statement->fetch()) {
             $rows[] = $row;
         }
 
@@ -433,7 +433,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
                 $queryBuilder->expr()->eq('qid', $queryBuilder->createNamedParameter($queueId))
             )
             ->execute()
-            ->fetchAssociative();
+            ->fetch();
         return is_array($queueRec) ? $queueRec : null;
     }
 
@@ -636,7 +636,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
 
         $statement = $queryBuilder->execute();
 
-        while ($row = $statement->fetchAssociative()) {
+        while ($row = $statement->fetch()) {
             $rows[] = $row['qid'];
         }
 
@@ -697,7 +697,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
             )
             ->setMaxResults(1)
             ->addOrderBy($orderByField, $orderBySorting)
-            ->execute()->fetchAssociative(0);
+            ->execute()->fetch(0);
 
         return $first ?: [];
     }

--- a/Classes/Hooks/IndexedSearchCrawlerHook.php
+++ b/Classes/Hooks/IndexedSearchCrawlerHook.php
@@ -91,7 +91,7 @@ class IndexedSearchCrawlerHook
             ->execute();
 
         // For each configuration, check if it should be executed and if so, start:
-        while ($cfgRec = $result->fetchAssociative()) {
+        while ($cfgRec = $result->fetch()) {
             // Generate a unique set-ID:
             $setId = GeneralUtility::md5int(microtime());
             // Get next time:
@@ -210,7 +210,7 @@ class IndexedSearchCrawlerHook
                     )
                 )
                 ->execute()
-                ->fetchAssociative();
+                ->fetch();
             if (is_array($cfgRec)) {
                 // Unpack session data:
                 $session_data = unserialize($cfgRec['session_data']);
@@ -304,7 +304,7 @@ class IndexedSearchCrawlerHook
                 ->execute();
 
             // Traverse:
-            while ($row = $result->fetchAssociative()) {
+            while ($row = $result->fetch()) {
                 // Index single record:
                 $this->indexSingleRecord($row, $cfgRec, $rootLine);
                 // Update the UID we last processed:
@@ -467,7 +467,7 @@ class IndexedSearchCrawlerHook
                 )
                 ->execute();
             // Traverse subpages and add to queue:
-            while ($row = $result->fetchAssociative()) {
+            while ($row = $result->fetch()) {
                 $this->instanceCounter++;
                 $url = 'pages:' . $row['uid'] . ': ' . $row['title'];
                 $session_data['urlLog'][] = $url;
@@ -904,7 +904,7 @@ class IndexedSearchCrawlerHook
                 )
                 ->execute();
 
-            while ($cfgRec = $result->fetchAssociative()) {
+            while ($cfgRec = $result->fetch()) {
                 $this->indexSingleRecord($currentRecord, $cfgRec);
             }
         }

--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -296,7 +296,7 @@ class ConfigurationService
                                 $statement = $queryBuilder->execute();
 
                                 $rows = [];
-                                while ($row = $statement->fetchAssociative()) {
+                                while ($row = $statement->fetch()) {
                                     $rows[$row[$fieldName]] = $row;
                                 }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
 			count: 1
 			path: Classes/Api/CrawlerApi.php
 
 		-
-			message: "#^Cannot call method fetchAssociative\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
 			count: 1
 			path: Classes/Api/CrawlerApi.php
 
@@ -37,6 +37,15 @@ parameters:
 		-
 			message:
 				"""
+					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
+					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
+				"""
+			count: 1
+			path: Classes/Backend/RequestForm/LogRequestForm.php
+
+		-
+			message:
+				"""
 					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
 					since TYPO3 10\\.4, will be removed in version 12\\.0$#
 				"""
@@ -54,11 +63,6 @@ parameters:
 			path: Classes/Backend/RequestForm/LogRequestForm.php
 
 		-
-			message: "#^Cannot access offset 'parameters' on array\\<string, mixed\\>\\|false\\.$#"
-			count: 2
-			path: Classes/Backend/RequestForm/LogRequestForm.php
-
-		-
 			message: "#^Cannot access offset 'procInstructions' on array\\|bool\\.$#"
 			count: 2
 			path: Classes/Backend/RequestForm/LogRequestForm.php
@@ -69,7 +73,7 @@ parameters:
 			path: Classes/Backend/RequestForm/LogRequestForm.php
 
 		-
-			message: "#^Cannot call method fetchAssociative\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\DriverStatement\\|int\\.$#"
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\DriverStatement\\|int\\.$#"
 			count: 1
 			path: Classes/Backend/RequestForm/LogRequestForm.php
 
@@ -249,6 +253,15 @@ parameters:
 		-
 			message:
 				"""
+					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
+					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
+				"""
+			count: 1
+			path: Classes/Controller/CrawlerController.php
+
+		-
+			message:
+				"""
 					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
 					since TYPO3 10\\.4, will be removed in version 12\\.0$#
 				"""
@@ -266,7 +279,7 @@ parameters:
 			path: Classes/Controller/CrawlerController.php
 
 		-
-			message: "#^Cannot call method fetchAssociative\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
 			count: 1
 			path: Classes/Controller/CrawlerController.php
 
@@ -357,9 +370,23 @@ parameters:
 		-
 			message:
 				"""
+					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
+					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
+				"""
+			count: 1
+			path: Classes/Domain/Repository/ConfigurationRepository.php
+
+		-
+			message:
+				"""
 					#^Call to deprecated method fetchAll\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
 					Use fetchAllNumeric\\(\\), fetchAllAssociative\\(\\) or fetchFirstColumn\\(\\) instead\\.$#
 				"""
+			count: 1
+			path: Classes/Domain/Repository/ConfigurationRepository.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
 			count: 1
 			path: Classes/Domain/Repository/ConfigurationRepository.php
 
@@ -369,14 +396,18 @@ parameters:
 			path: Classes/Domain/Repository/ConfigurationRepository.php
 
 		-
-			message: "#^Cannot call method fetchAssociative\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1
 			path: Classes/Domain/Repository/ConfigurationRepository.php
 
 		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: Classes/Domain/Repository/ConfigurationRepository.php
+			message:
+				"""
+					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
+					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
+				"""
+			count: 4
+			path: Classes/Domain/Repository/ProcessRepository.php
 
 		-
 			message:
@@ -397,13 +428,13 @@ parameters:
 			path: Classes/Domain/Repository/ProcessRepository.php
 
 		-
-			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
-			count: 1
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			count: 4
 			path: Classes/Domain/Repository/ProcessRepository.php
 
 		-
-			message: "#^Cannot call method fetchAssociative\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
-			count: 4
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			count: 1
 			path: Classes/Domain/Repository/ProcessRepository.php
 
 		-
@@ -434,6 +465,15 @@ parameters:
 		-
 			message:
 				"""
+					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
+					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
+				"""
+			count: 9
+			path: Classes/Domain/Repository/QueueRepository.php
+
+		-
+			message:
+				"""
 					#^Call to deprecated method fetchAll\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
 					Use fetchAllNumeric\\(\\), fetchAllAssociative\\(\\) or fetchFirstColumn\\(\\) instead\\.$#
 				"""
@@ -450,13 +490,13 @@ parameters:
 			path: Classes/Domain/Repository/QueueRepository.php
 
 		-
-			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
-			count: 4
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			count: 9
 			path: Classes/Domain/Repository/QueueRepository.php
 
 		-
-			message: "#^Cannot call method fetchAssociative\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
-			count: 9
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			count: 4
 			path: Classes/Domain/Repository/QueueRepository.php
 
 		-
@@ -559,13 +599,13 @@ parameters:
 			path: Classes/Hooks/IndexedSearchCrawlerHook.php
 
 		-
-			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
-			count: 3
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			count: 5
 			path: Classes/Hooks/IndexedSearchCrawlerHook.php
 
 		-
-			message: "#^Cannot call method fetchAssociative\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
-			count: 5
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			count: 3
 			path: Classes/Hooks/IndexedSearchCrawlerHook.php
 
 		-
@@ -649,6 +689,15 @@ parameters:
 		-
 			message:
 				"""
+					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
+					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
+				"""
+			count: 1
+			path: Classes/Service/ConfigurationService.php
+
+		-
+			message:
+				"""
 					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
 					since TYPO3 10\\.4, will be removed in version 12\\.0$#
 				"""
@@ -656,7 +705,7 @@ parameters:
 			path: Classes/Service/ConfigurationService.php
 
 		-
-			message: "#^Cannot call method fetchAssociative\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
 			count: 1
 			path: Classes/Service/ConfigurationService.php
 


### PR DESCRIPTION
https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/Installation/LegacyInstallation.html
https://github.com/TYPO3/typo3/blob/10.4/composer.lock#L220