### PR TITLE
[BUGFIX] Display text in confirm dialog in backend module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 * PHP8 undefined array keys in CrawlerController, ConfigurationService and middlewares
+* Text not displayed in confirm dialog in backend module
 
 ### Deprecated
 #### Classes

--- a/Resources/Private/Templates/Backend/ShowLog.html
+++ b/Resources/Private/Templates/Backend/ShowLog.html
@@ -61,11 +61,11 @@
             <input type="submit" class="btn btn-default"
                    value="{f:translate(key: 'LLL:EXT:crawler/Resources/Private/Language/locallang.xlf:labels.flushvisiblequeue')}"
                    name="_flush"
-                   onclick="return confirm('{f:translate(key: 'crawler/Resources/Private/Language/locallang.xlf:labels.confirmyouresure')}')"/>
+                   onclick="return confirm('{f:translate(key: 'LLL:EXT:crawler/Resources/Private/Language/locallang.xlf:labels.confirmyouresure')}')"/>
             <input type="submit" class="btn btn-default"
                    value="{f:translate(key: 'LLL:EXT:crawler/Resources/Private/Language/locallang.xlf:labels.flushfullqueue')}"
                    name="_flush_all"
-                   onclick="return confirm('{f:translate(key: 'crawler/Resources/Private/Language/locallang.xlf:labels.confirmyouresure')}')"/>
+                   onclick="return confirm('{f:translate(key: 'LLL:EXT:crawler/Resources/Private/Language/locallang.xlf:labels.confirmyouresure')}')"/>
             <br>
             <br>
             <table class="table table-hover">


### PR DESCRIPTION
## Description

The text was not displayed in the confirm dialog in the backend module due to wrong translation keys.

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
