### PR TITLE
[BUGFIX] Fix DateTime parse error in backend module when displaying log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 ### Fixed
+* DateTime parse error in backend module when displaying log
 * PHP8 undefined array keys in CrawlerController, ConfigurationService and middlewares
 
 ### Deprecated

--- a/Classes/Backend/RequestForm/LogRequestForm.php
+++ b/Classes/Backend/RequestForm/LogRequestForm.php
@@ -366,7 +366,7 @@ final class LogRequestForm extends AbstractRequestForm implements RequestFormInt
                 if (isset($this->infoModuleController->MOD_SETTINGS['log_resultLog'])) {
                     $rowData['result_log'] = $resLog;
                 } else {
-                    $rowData['scheduled'] = ($vv['scheduled'] > 0) ? BackendUtility::datetime($vv['scheduled']) : 0;
+                    $rowData['scheduled'] = ($vv['scheduled'] > 0) ? BackendUtility::datetime($vv['scheduled']) : '-';
                     $rowData['exec_time'] = $execTime;
                 }
                 $rowData['result_status'] = GeneralUtility::fixed_lgd_cs($resStatus, 50);

--- a/Resources/Private/Templates/Backend/ShowLog.html
+++ b/Resources/Private/Templates/Backend/ShowLog.html
@@ -144,17 +144,10 @@
                                                 </td>
                                             </f:then>
                                             <f:else>
-                                                <td>{logEntry.columns.scheduled -> f:format.date(format: 'd.m.Y H:i')}</td>
+                                                <td>{logEntry.columns.scheduled}</td>
                                             </f:else>
                                         </f:if>
-                                        <f:if condition="{logEntry.columns.exec_time} = '-'">
-                                            <f:then>
-                                                <td>{logEntry.columns.exec_time}</td>
-                                            </f:then>
-                                            <f:else>
-                                                <td>{logEntry.columns.exec_time -> f:format.date(format: 'd.m.Y H:i')}</td>
-                                            </f:else>
-                                        </f:if>
+                                        <td>{logEntry.columns.exec_time}</td>
                                     </f:else>
                                 </f:if>
                                 <td>{logEntry.columns.result_status}</td>


### PR DESCRIPTION
Resolves: #865

## Description

The patch fixes the error

    “20.12.21 14:51” could not be parsed by \DateTime constructor: DateTime::__construct()

The dates are parsed already through BackendUtility::datetime() so the variable can be displayed unchanged.

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
