### PR TITLE
[TASK] Register icons via service container

### DIFF
--- a/Classes/Utility/BackendUtility.php
+++ b/Classes/Utility/BackendUtility.php
@@ -22,6 +22,7 @@ namespace AOE\Crawler\Utility;
 use AOE\Crawler\Backend\BackendModule;
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
 use TYPO3\CMS\Core\Imaging\IconRegistry;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -49,9 +50,13 @@ class BackendUtility
      */
     public static function registerIcons(): void
     {
-        self::registerCrawlerIcon();
-        self::registerStartIcon();
-        self::registerStopIcon();
+        if ((new Typo3Version())->getMajorVersion() === 10) {
+            // This method can be deleted once compatibility with TYPO3 v10 is removed.
+            // See Configuration/Icons.php for the way to go in TYPO3 v11+
+            self::registerCrawlerIcon();
+            self::registerStartIcon();
+            self::registerStopIcon();
+        }
     }
 
     /**

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+
+return [
+    'tx-crawler' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:crawler/Resources/Public/Icons/crawler_configuration.svg',
+    ],
+    'tx-crawler-start' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:crawler/Resources/Public/Icons/crawler_start.svg',
+    ],
+    'tx-crawler-stop' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:crawler/Resources/Public/Icons/crawler_stop.svg',
+    ],
+];


### PR DESCRIPTION
## Description

This improves the loading speed of every request in TYPO3 v11+.
In TYPO3 v10 the old way to register icons is used.

See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Feature-94692-RegisteringIconsViaServiceContainer.html

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
