### PR TITLE
[BUGFIX] Fix undefined array key when creating configuration record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 
 ### Fixed
+* PHP8 undefined array key when creating/updating/saving configuration record
 
 ### Deprecated
 #### Classes

--- a/Classes/Utility/TcaUtility.php
+++ b/Classes/Utility/TcaUtility.php
@@ -36,7 +36,7 @@ class TcaUtility
     public function getProcessingInstructions(array $configuration)
     {
         $configuration = $configuration ?? ['items' => []];
-        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['crawler']['procInstructions'])) {
+        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['crawler']['procInstructions'] ?? null)) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['crawler']['procInstructions'] as $extensionKey => $extensionConfiguration) {
                 $configuration['items'][] = [$extensionConfiguration['value'] . ' [' . $extensionConfiguration['key'] . ']', $extensionConfiguration['key'], $this->getExtensionIcon($extensionKey)];
             }


### PR DESCRIPTION
## Description

This PR fixes an undefined array key on PHP 80 when creating, updating or saving
a configuration record.

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
