### PR TITLE
[TASK] Deprecating not internally used functions in repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@
 ### Deprecated
 #### Classes
 #### Functions & Properties
+* ConfigurationRepository->getCrawlerConfigurationRecords()
+* ProcessRepository->findByProcessId()
+* QueueRepository->countAllUnassignedPendingItems()
+* QueueRepository->countPendingItemsGroupedByConfigurationKey()
+* QueueRepository->getSetIdWithUnprocessedEntries()
+* QueueRepository->getTotalQueueEntriesByConfiguration()
+* QueueRepository->getLastProcessedEntriesTimestamps()
+* QueueRepository->getLastProcessedEntries()
+* QueueRepository->getPerformanceData()
+* QueueRepository->isPageInQueueTimed()
+* QueueRepository->getAvailableSets()
+* QueueRepository->findByQueueId()
 
 ### Removed
 #### Classes

--- a/Classes/Domain/Repository/ConfigurationRepository.php
+++ b/Classes/Domain/Repository/ConfigurationRepository.php
@@ -35,6 +35,9 @@ class ConfigurationRepository extends Repository
 {
     public const TABLE_NAME = 'tx_crawler_configuration';
 
+    /**
+     * @deprecated since 11.0.4 will be removed v13.x
+     */
     public function getCrawlerConfigurationRecords(): array
     {
         $records = [];

--- a/Classes/Domain/Repository/ProcessRepository.php
+++ b/Classes/Domain/Repository/ProcessRepository.php
@@ -100,6 +100,7 @@ class ProcessRepository extends Repository
 
     /**
      * @param string $processId
+     * @deprecated since 11.0.4 will be removed v13.x
      */
     public function findByProcessId($processId)
     {

--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -179,8 +179,10 @@ class QueueRepository extends Repository implements LoggerAwareInterface
     }
 
     /**
-     * This method can be used to count all queue entrys which are
-     * scheduled for now or a earlier date and are not assigned to a process.
+     * This method can be used to count all queue entries which are
+     * scheduled for now or an earlier date and are not assigned to a process.
+     *
+     * @deprecated since 11.0.4 will be removed v13.x
      */
     public function countAllUnassignedPendingItems(): int
     {
@@ -200,6 +202,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
 
     /**
      * Count pending queue entries grouped by configuration key
+     * @deprecated since 11.0.4 will be removed v13.x
      */
     public function countPendingItemsGroupedByConfigurationKey(): array
     {
@@ -222,6 +225,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
      * Get set id with unprocessed entries
      *
      * @return array array of set ids
+     * @deprecated since 11.0.4 will be removed v13.x
      */
     public function getSetIdWithUnprocessedEntries(): array
     {
@@ -248,6 +252,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
      * Get total queue entries by configuration
      *
      * @return array totals by configuration (keys)
+     * @deprecated since 11.0.4 will be removed v13.x
      */
     public function getTotalQueueEntriesByConfiguration(array $setIds): array
     {
@@ -277,6 +282,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
      * Get the timestamps of the last processed entries
      *
      * @param int $limit
+     * @deprecated since 11.0.4 will be removed v13.x
      */
     public function getLastProcessedEntriesTimestamps($limit = 100): array
     {
@@ -298,6 +304,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
 
     /**
      * Get the last processed entries
+     * @deprecated since 11.0.4 will be removed v13.x
      */
     public function getLastProcessedEntries(int $limit = 100): array
     {
@@ -324,6 +331,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
      * @param int $end timestamp
      *
      * @return array performance data
+     * @deprecated since 11.0.4 will be removed v13.x
      */
     public function getPerformanceData($start, $end): array
     {
@@ -396,12 +404,16 @@ class QueueRepository extends Repository implements LoggerAwareInterface
     /**
      * Method to check if a page is in the queue which is timed for a
      * date when it should be crawled
+     * @deprecated since 11.0.4 will be removed v13.x
      */
     public function isPageInQueueTimed(int $uid, bool $show_unprocessed = true): bool
     {
         return $this->isPageInQueue($uid, $show_unprocessed);
     }
 
+    /**
+     * @deprecated since 11.0.4 will be removed v13.x
+     */
     public function getAvailableSets(): array
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::TABLE_NAME);
@@ -421,6 +433,9 @@ class QueueRepository extends Repository implements LoggerAwareInterface
         return $rows;
     }
 
+    /**
+     * @deprecated since 11.0.4 will be removed v13.x
+     */
     public function findByQueueId(string $queueId): ?array
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::TABLE_NAME);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -360,15 +360,6 @@ parameters:
 		-
 			message:
 				"""
-					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
-					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
-				"""
-			count: 1
-			path: Classes/Domain/Repository/ConfigurationRepository.php
-
-		-
-			message:
-				"""
 					#^Call to deprecated method fetchAll\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
 					Use fetchAllNumeric\\(\\), fetchAllAssociative\\(\\) or fetchFirstColumn\\(\\) instead\\.$#
 				"""
@@ -396,7 +387,7 @@ parameters:
 					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
 					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
 				"""
-			count: 4
+			count: 3
 			path: Classes/Domain/Repository/ProcessRepository.php
 
 		-
@@ -468,7 +459,7 @@ parameters:
 					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
 					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
 				"""
-			count: 9
+			count: 2
 			path: Classes/Domain/Repository/QueueRepository.php
 
 		-
@@ -477,7 +468,7 @@ parameters:
 					#^Call to deprecated method fetchAll\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
 					Use fetchAllNumeric\\(\\), fetchAllAssociative\\(\\) or fetchFirstColumn\\(\\) instead\\.$#
 				"""
-			count: 4
+			count: 3
 			path: Classes/Domain/Repository/QueueRepository.php
 
 		-
@@ -486,7 +477,7 @@ parameters:
 					#^Call to deprecated method fetchColumn\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
 					Use fetchOne\\(\\) instead\\.$#
 				"""
-			count: 7
+			count: 6
 			path: Classes/Domain/Repository/QueueRepository.php
 
 		-


### PR DESCRIPTION
Will be removed in v13.x
* ConfigurationRepository->getCrawlerConfigurationRecords()
* ProcessRepository->findByProcessId()
* QueueRepository->countAllUnassignedPendingItems()
* QueueRepository->countPendingItemsGroupedByConfigurationKey()
* QueueRepository->getSetIdWithUnprocessedEntries()
* QueueRepository->getTotalQueueEntriesByConfiguration()
* QueueRepository->getLastProcessedEntriesTimestamps()
* QueueRepository->getLastProcessedEntries()
* QueueRepository->getPerformanceData()
* QueueRepository->isPageInQueueTimed()
* QueueRepository->getAvailableSets()
* QueueRepository->findByQueueId()

## Description

<!-- What does this PR do -->

<!-- Does this solve an existing issue, then please reference with #issue-number -->

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
