### PR TITLE
Bugfix/trusted host pattern failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+* Fatal PHP error is thrown in the backend crawler log
 
 ### Deprecated
 #### Classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+* Crawler could not index frontend because of trustedHostPattern mismatch
 * Fatal PHP error is thrown in the backend crawler log
 
 ### Deprecated

--- a/Classes/Backend/RequestForm/LogRequestForm.php
+++ b/Classes/Backend/RequestForm/LogRequestForm.php
@@ -370,7 +370,7 @@ final class LogRequestForm extends AbstractRequestForm implements RequestFormInt
                     $rowData['exec_time'] = $execTime;
                 }
                 $rowData['result_status'] = GeneralUtility::fixed_lgd_cs($resStatus, 50);
-                $url = htmlspecialchars($parameters['url'] ?? $parameters['alturl'], ENT_QUOTES | ENT_HTML5);
+                $url = htmlspecialchars((string)($parameters['url'] ?? $parameters['alturl']), ENT_QUOTES | ENT_HTML5);
                 $rowData['url'] = '<a href="' . $url . '" target="_newWIndow">' . $url . '</a>';
                 $rowData['feUserGroupList'] = $parameters['feUserGroupList'] ?? '';
                 $rowData['procInstructions'] = is_array($parameters['procInstructions']) ? implode('; ', $parameters['procInstructions']) : '';

--- a/Classes/Backend/RequestForm/LogRequestForm.php
+++ b/Classes/Backend/RequestForm/LogRequestForm.php
@@ -370,7 +370,7 @@ final class LogRequestForm extends AbstractRequestForm implements RequestFormInt
                     $rowData['exec_time'] = $execTime;
                 }
                 $rowData['result_status'] = GeneralUtility::fixed_lgd_cs($resStatus, 50);
-                $url = htmlspecialchars((string)($parameters['url'] ?? $parameters['alturl']), ENT_QUOTES | ENT_HTML5);
+                $url = htmlspecialchars((string) ($parameters['url'] ?? $parameters['alturl']), ENT_QUOTES | ENT_HTML5);
                 $rowData['url'] = '<a href="' . $url . '" target="_newWIndow">' . $url . '</a>';
                 $rowData['feUserGroupList'] = $parameters['feUserGroupList'] ?? '';
                 $rowData['procInstructions'] = is_array($parameters['procInstructions']) ? implode('; ', $parameters['procInstructions']) : '';

--- a/cli/bootstrap.php
+++ b/cli/bootstrap.php
@@ -66,16 +66,18 @@ $_SERVER['SCRIPT_FILENAME'] = $_SERVER['PATH_TRANSLATED'] = $typo3Root . 'index.
 $_SERVER['QUERY_STRING'] = (isset($urlParts['query']) ? $urlParts['query'] : '');
 $_SERVER['REQUEST_URI'] = $urlParts['path'] . (isset($urlParts['query']) ? '?' . $urlParts['query'] : '');
 $_SERVER['REQUEST_METHOD'] = 'GET';
+$_SERVER['SERVER_PORT'] = '80';
+
+    // Define HTTPS disposal:
+if ($urlParts['scheme'] === 'https') {
+    $_SERVER['HTTPS'] = 'on';
+    $_SERVER['SERVER_PORT'] = '443';
+}
 
     // Define a port if used in the URL:
 if (isset($urlParts['port'])) {
     $_SERVER['HTTP_HOST'] .= ':' . $urlParts['port'];
     $_SERVER['SERVER_PORT'] = (string)$urlParts['port'];
-}
-
-    // Define HTTPS disposal:
-if ($urlParts['scheme'] === 'https') {
-    $_SERVER['HTTPS'] = 'on';
 }
 
 chdir($typo3Root);


### PR DESCRIPTION
## Description

The problem was that the crawler could not crawl websites in the frontend on the production server. The problem was a trusted host pattern fail due to the check of the server port that was never been set: https://github.com/TYPO3/typo3/blob/10.4/typo3/sysext/core/Classes/Utility/GeneralUtility.php#L2929

Additionally a type mismatch error on the crawler log in the backend was fixed.

Maybe this could be the same problem as described in #757 🤔 

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
