### PR TITLE
[TASK] Switch from ObjectManager->get to GeneralUtility::makeInstance

### DIFF
--- a/Classes/Api/CrawlerApi.php
+++ b/Classes/Api/CrawlerApi.php
@@ -37,7 +37,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Class CrawlerApi
@@ -74,9 +73,7 @@ class CrawlerApi
 
     public function __construct()
     {
-        /** @var ObjectManager $objectManager */
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->queueRepository = $objectManager->get(QueueRepository::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
     }
 
     /**
@@ -447,6 +444,6 @@ class CrawlerApi
 
     private function getPageRepository(): PageRepository
     {
-        return GeneralUtility::makeInstance(ObjectManager::class)->get(PageRepository::class);
+        return GeneralUtility::makeInstance(PageRepository::class);
     }
 }

--- a/Classes/Backend/BackendModule.php
+++ b/Classes/Backend/BackendModule.php
@@ -38,7 +38,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 use TYPO3\CMS\Info\Controller\InfoModuleController;
 
@@ -92,10 +91,9 @@ class BackendModule
 
     public function __construct()
     {
-        $objectManger = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->processManager = $objectManger->get(ProcessService::class);
+        $this->processManager = GeneralUtility::makeInstance(ProcessService::class);
         $this->queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(QueueRepository::TABLE_NAME);
-        $this->queueRepository = $objectManger->get(QueueRepository::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
         $this->initializeView();
         $this->extensionSettings = GeneralUtility::makeInstance(ExtensionConfigurationProvider::class)->getExtensionConfiguration();
     }

--- a/Classes/Backend/RequestForm/LogRequestForm.php
+++ b/Classes/Backend/RequestForm/LogRequestForm.php
@@ -20,7 +20,6 @@ use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Utility\DebugUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 use TYPO3\CMS\Info\Controller\InfoModuleController;
 
@@ -73,14 +72,13 @@ final class LogRequestForm extends AbstractRequestForm implements RequestFormInt
 
     public function __construct(StandaloneView $view, InfoModuleController $infoModuleController, array $extensionSettings)
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $this->view = $view;
         $this->infoModuleController = $infoModuleController;
         $this->jsonCompatibilityConverter = new JsonCompatibilityConverter();
         $this->queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(QueueRepository::TABLE_NAME);
         $this->csvWriter = new CrawlerCsvWriter();
         $this->extensionSettings = $extensionSettings;
-        $this->queueRepository = $objectManager->get(QueueRepository::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
     }
 
     public function render(int $id, string $elementName, array $menuItems): string

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -36,7 +36,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class BuildQueueCommand extends Command
 {
@@ -121,12 +120,11 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
 
         $extensionSettings = GeneralUtility::makeInstance(ExtensionConfigurationProvider::class)->getExtensionConfiguration();
         $eventDispatcher = GeneralUtility::makeInstance(EventDispatcher::class);
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
 
         /** @var CrawlerController $crawlerController */
-        $crawlerController = $objectManager->get(CrawlerController::class);
+        $crawlerController = GeneralUtility::makeInstance(CrawlerController::class);
         /** @var QueueRepository $queueRepository */
-        $queueRepository = $objectManager->get(QueueRepository::class);
+        $queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
 
         if ($mode === 'exec') {
             $crawlerController->registerQueueEntriesInternallyOnly = true;

--- a/Classes/Command/FlushQueueCommand.php
+++ b/Classes/Command/FlushQueueCommand.php
@@ -26,7 +26,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class FlushQueueCommand extends Command
 {
@@ -70,12 +69,10 @@ It will remove queue entries and perform a cleanup.' . chr(10) . chr(10) .
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-
         $queueFilter = new QueueFilter($input->getArgument('mode'));
 
         /** @var QueueRepository $queueRepository */
-        $queueRepository = $objectManager->get(QueueRepository::class);
+        $queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
 
         switch ($queueFilter) {
             case 'all':

--- a/Classes/Command/ProcessQueueCommand.php
+++ b/Classes/Command/ProcessQueueCommand.php
@@ -30,7 +30,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class ProcessQueueCommand extends Command
 {
@@ -86,15 +85,14 @@ class ProcessQueueCommand extends Command
         $sleeptime = $input->getOption('sleeptime');
         $sleepafter = $input->getOption('sleepafter');
 
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $this->extensionSettings = $this->getExtensionSettings();
 
         $result = self::CLI_STATUS_NOTHING_PROCCESSED;
 
         /** @var QueueRepository $queueRepository */
-        $queueRepository = $objectManager->get(QueueRepository::class);
+        $queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
         /** @var ProcessRepository $processRepository */
-        $processRepository = $objectManager->get(ProcessRepository::class);
+        $processRepository = GeneralUtility::makeInstance(ProcessRepository::class);
 
         /** @var Crawler $crawler */
         $crawler = GeneralUtility::makeInstance(Crawler::class);

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -51,7 +51,6 @@ use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\Utility\DebugUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Class CrawlerController
@@ -207,11 +206,10 @@ class CrawlerController implements LoggerAwareInterface
 
     public function __construct()
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $crawlStrategyFactory = GeneralUtility::makeInstance(CrawlStrategyFactory::class);
-        $this->queueRepository = $objectManager->get(QueueRepository::class);
-        $this->processRepository = $objectManager->get(ProcessRepository::class);
-        $this->configurationRepository = $objectManager->get(ConfigurationRepository::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
+        $this->processRepository = GeneralUtility::makeInstance(ProcessRepository::class);
+        $this->configurationRepository = GeneralUtility::makeInstance(ConfigurationRepository::class);
         $this->pageRepository = GeneralUtility::makeInstance(PageRepository::class);
         $this->queueExecutor = GeneralUtility::makeInstance(QueueExecutor::class, $crawlStrategyFactory);
         $this->iconFactory = GeneralUtility::makeInstance(IconFactory::class);

--- a/Classes/Domain/Model/Process.php
+++ b/Classes/Domain/Model/Process.php
@@ -22,7 +22,6 @@ namespace AOE\Crawler\Domain\Model;
 use AOE\Crawler\Domain\Repository\QueueRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Class Process
@@ -75,8 +74,7 @@ class Process extends AbstractEntity
 
     public function __construct()
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->queueRepository = $objectManager->get(QueueRepository::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
     }
 
     /**

--- a/Classes/Hooks/ProcessCleanUpHook.php
+++ b/Classes/Hooks/ProcessCleanUpHook.php
@@ -24,7 +24,6 @@ use AOE\Crawler\Domain\Repository\ProcessRepository;
 use AOE\Crawler\Domain\Repository\QueueRepository;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * @internal since v9.2.5
@@ -53,9 +52,8 @@ class ProcessCleanUpHook implements CrawlerHookInterface
 
     public function __construct()
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->processRepository = $objectManager->get(ProcessRepository::class);
-        $this->queueRepository = $objectManager->get(QueueRepository::class);
+        $this->processRepository = GeneralUtility::makeInstance(ProcessRepository::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
     }
 
     /**

--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -33,7 +33,6 @@ use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * @internal since v9.2.5
@@ -62,9 +61,8 @@ class ConfigurationService
 
     public function __construct()
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $this->urlService = GeneralUtility::makeInstance(UrlService::class);
-        $this->configurationRepository = $objectManager->get(ConfigurationRepository::class);
+        $this->configurationRepository = GeneralUtility::makeInstance(ConfigurationRepository::class);
         $this->extensionSettings = GeneralUtility::makeInstance(ExtensionConfigurationProvider::class)->getExtensionConfiguration();
     }
 

--- a/Classes/Service/ProcessService.php
+++ b/Classes/Service/ProcessService.php
@@ -28,7 +28,6 @@ use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * @package AOE\Crawler\Service
@@ -55,8 +54,7 @@ class ProcessService
 
     public function __construct()
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->processRepository = $objectManager->get(ProcessRepository::class);
+        $this->processRepository = GeneralUtility::makeInstance(ProcessRepository::class);
         $this->extensionSettings = GeneralUtility::makeInstance(ExtensionConfigurationProvider::class)->getExtensionConfiguration();
         $this->timeToLive = (int) $this->extensionSettings['processMaxRunTime'];
     }

--- a/Tests/Functional/Api/CrawlerApiTest.php
+++ b/Tests/Functional/Api/CrawlerApiTest.php
@@ -34,7 +34,6 @@ use AOE\Crawler\Domain\Repository\QueueRepository;
 use AOE\Crawler\Tests\Functional\SiteBasedTestTrait;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Class CrawlerApiTest
@@ -79,8 +78,6 @@ class CrawlerApiTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-
         //restore old rootline
         $this->oldRootline = $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'];
         //clear rootline
@@ -107,8 +104,8 @@ class CrawlerApiTest extends FunctionalTestCase
         ];
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['crawler'] = $configuration;
 
-        $this->subject = $objectManager->get(CrawlerApi::class);
-        $this->queueRepository = $objectManager->get(QueueRepository::class);
+        $this->subject = GeneralUtility::makeInstance(CrawlerApi::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
 
         $this->importDataSet(__DIR__ . '/../data/pages.xml');
         $this->importDataSet(__DIR__ . '/../data/sys_template.xml');

--- a/Tests/Functional/Command/BuildQueueCommandTest.php
+++ b/Tests/Functional/Command/BuildQueueCommandTest.php
@@ -26,7 +26,6 @@ use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class BuildQueueCommandTest extends FunctionalTestCase
 {
@@ -61,7 +60,7 @@ class BuildQueueCommandTest extends FunctionalTestCase
 
         $this->importDataSet(__DIR__ . '/../Fixtures/pages.xml');
         $this->importDataSet(__DIR__ . '/../Fixtures/tx_crawler_configuration.xml');
-        $this->queueRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(QueueRepository::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
 
         $this->writeSiteConfiguration(
             'acme-com',

--- a/Tests/Functional/Command/FlushQueueCommandTest.php
+++ b/Tests/Functional/Command/FlushQueueCommandTest.php
@@ -24,7 +24,6 @@ use AOE\Crawler\Domain\Repository\QueueRepository;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class FlushQueueCommandTest extends FunctionalTestCase
 {
@@ -48,7 +47,7 @@ class FlushQueueCommandTest extends FunctionalTestCase
         parent::setUp();
 
         $this->importDataSet(__DIR__ . '/../Fixtures/tx_crawler_queue.xml');
-        $this->queueRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(QueueRepository::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
 
         $command = new FlushQueueCommand();
         $this->commandTester = new CommandTester($command);

--- a/Tests/Functional/Domain/Repository/ConfigurationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/ConfigurationRepositoryTest.php
@@ -22,7 +22,6 @@ namespace AOE\Crawler\Tests\Functional\Domain\Repository;
 use AOE\Crawler\Domain\Repository\ConfigurationRepository;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class ConfigurationRepositoryTest extends FunctionalTestCase
 {
@@ -44,9 +43,7 @@ class ConfigurationRepositoryTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->subject = $objectManager->get(ConfigurationRepository::class);
+        $this->subject = GeneralUtility::makeInstance(ConfigurationRepository::class);
         $this->importDataSet(__DIR__ . '/../../Fixtures/tx_crawler_configuration.xml');
         $this->importDataSet(__DIR__ . '/../../Fixtures/pages.xml');
     }

--- a/Tests/Functional/Domain/Repository/ProcessRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/ProcessRepositoryTest.php
@@ -23,7 +23,6 @@ use AOE\Crawler\Domain\Repository\ProcessRepository;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Class ProcessRepositoryTest
@@ -43,19 +42,13 @@ class ProcessRepositoryTest extends FunctionalTestCase
     protected $subject;
 
     /**
-     * @var \TYPO3\CMS\Extbase\Object\ObjectManagerInterface The object manager
-     */
-    protected $objectManager;
-
-    /**
      * Creates the test environment.
      */
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->subject = $this->objectManager->get(ProcessRepository::class);
+        $this->subject = GeneralUtility::makeInstance(ProcessRepository::class);
 
         $configuration = [
             'sleepTime' => '1000',

--- a/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
@@ -25,7 +25,6 @@ use AOE\Crawler\Value\QueueFilter;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Class QueryRepositoryTest
@@ -51,11 +50,10 @@ class QueueRepositoryTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $this->importDataSet(__DIR__ . '/../../Fixtures/tx_crawler_queue.xml');
         $this->importDataSet(__DIR__ . '/../../Fixtures/pages.xml');
 
-        $this->subject = $objectManager->get(QueueRepository::class);
+        $this->subject = GeneralUtility::makeInstance(QueueRepository::class);
     }
 
     /**
@@ -544,8 +542,7 @@ class QueueRepositoryTest extends FunctionalTestCase
      */
     public function flushQueue(QueueFilter $queueFilter, int $expected): void
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $queryRepository = $objectManager->get(QueueRepository::class);
+        $queryRepository = GeneralUtility::makeInstance(QueueRepository::class);
         $this->subject->flushQueue($queueFilter);
 
         self::assertSame(

--- a/Tests/Functional/Hooks/ProcessCleanUpHookTest.php
+++ b/Tests/Functional/Hooks/ProcessCleanUpHookTest.php
@@ -24,7 +24,6 @@ use AOE\Crawler\Domain\Repository\QueueRepository;
 use AOE\Crawler\Hooks\ProcessCleanUpHook;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Class ProcessCleanUpHookTest
@@ -49,11 +48,6 @@ class ProcessCleanUpHookTest extends FunctionalTestCase
     protected $queueRepository;
 
     /**
-     * @var \TYPO3\CMS\Extbase\Object\ObjectManager
-     */
-    protected $objectManager;
-
-    /**
      * @var array
      */
     protected $testExtensionsToLoad = ['typo3conf/ext/crawler'];
@@ -62,12 +56,10 @@ class ProcessCleanUpHookTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-
         /** @var ProcessCleanUpHook $this->subject */
-        $this->subject = $this->objectManager->get(ProcessCleanUpHook::class);
-        $this->processRepository = $this->objectManager->get(ProcessRepository::class);
-        $this->queueRepository = $this->objectManager->get(QueueRepository::class);
+        $this->subject = GeneralUtility::makeInstance(ProcessCleanUpHook::class);
+        $this->processRepository = GeneralUtility::makeInstance(ProcessRepository::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
 
         // Include Fixtures
         $this->importDataSet(__DIR__ . '/../Fixtures/tx_crawler_process.xml');

--- a/Tests/Functional/Service/ProcessServiceTest.php
+++ b/Tests/Functional/Service/ProcessServiceTest.php
@@ -22,7 +22,6 @@ namespace AOE\Crawler\Tests\Functional\Service;
 use AOE\Crawler\Service\ProcessService;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Class ProcessServiceTest
@@ -48,7 +47,7 @@ class ProcessServiceTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->subject = GeneralUtility::makeInstance(ObjectManager::class)->get(ProcessService::class);
+        $this->subject = GeneralUtility::makeInstance(ProcessService::class);
     }
 
     /**

--- a/Tests/Functional/Service/QueueServiceTest.php
+++ b/Tests/Functional/Service/QueueServiceTest.php
@@ -24,7 +24,6 @@ use AOE\Crawler\Domain\Repository\QueueRepository;
 use AOE\Crawler\Service\QueueService;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class QueueServiceTest extends FunctionalTestCase
 {
@@ -54,7 +53,7 @@ class QueueServiceTest extends FunctionalTestCase
 
         $this->subject = $this->createPartialMock(QueueService::class, []);
         $this->subject->injectCrawlerController($crawlerController);
-        $this->queueRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(QueueRepository::class);
+        $this->queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
     }
 
     /**

--- a/Tests/Functional/Service/UrlServiceTest.php
+++ b/Tests/Functional/Service/UrlServiceTest.php
@@ -24,7 +24,6 @@ use AOE\Crawler\Tests\Functional\SiteBasedTestTrait;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class UrlServiceTest extends FunctionalTestCase
 {
@@ -57,7 +56,7 @@ class UrlServiceTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->subject = GeneralUtility::makeInstance(ObjectManager::class)->get(UrlService::class);
+        $this->subject = GeneralUtility::makeInstance(UrlService::class);
 
         $this->importDataSet(__DIR__ . '/../data/pages.xml');
         $this->importDataSet(__DIR__ . '/../data/sys_template.xml');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,26 +13,8 @@ parameters:
 		-
 			message:
 				"""
-					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
-					since TYPO3 10\\.4, will be removed in version 12\\.0$#
-				"""
-			count: 2
-			path: Classes/Backend/BackendModule.php
-
-		-
-			message:
-				"""
 					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\:
 					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
-				"""
-			count: 1
-			path: Classes/Backend/RequestForm/LogRequestForm.php
-
-		-
-			message:
-				"""
-					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
-					since TYPO3 10\\.4, will be removed in version 12\\.0$#
 				"""
 			count: 1
 			path: Classes/Backend/RequestForm/LogRequestForm.php
@@ -58,7 +40,7 @@ parameters:
 			path: Classes/Backend/RequestForm/LogRequestForm.php
 
 		-
-			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\.$#"
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
 			count: 1
 			path: Classes/Backend/RequestForm/LogRequestForm.php
 
@@ -108,40 +90,13 @@ parameters:
 			path: Classes/Backend/RequestForm/StartRequestForm.php
 
 		-
-			message:
-				"""
-					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
-					since TYPO3 10\\.4, will be removed in version 12\\.0$#
-				"""
-			count: 2
-			path: Classes/Command/BuildQueueCommand.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|null given\\.$#"
 			count: 1
 			path: Classes/Command/BuildQueueCommand.php
 
 		-
-			message:
-				"""
-					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
-					since TYPO3 10\\.4, will be removed in version 12\\.0$#
-				"""
-			count: 1
-			path: Classes/Command/FlushQueueCommand.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:crawler_init\\(\\)\\.$#"
 			count: 1
-			path: Classes/Command/ProcessQueueCommand.php
-
-		-
-			message:
-				"""
-					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
-					since TYPO3 10\\.4, will be removed in version 12\\.0$#
-				"""
-			count: 2
 			path: Classes/Command/ProcessQueueCommand.php
 
 		-
@@ -176,15 +131,6 @@ parameters:
 					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
 				"""
 			count: 1
-			path: Classes/Controller/CrawlerController.php
-
-		-
-			message:
-				"""
-					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
-					since TYPO3 10\\.4, will be removed in version 12\\.0$#
-				"""
-			count: 3
 			path: Classes/Controller/CrawlerController.php
 
 		-
@@ -266,15 +212,6 @@ parameters:
 			message: "#^Cannot call method info\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#"
 			count: 1
 			path: Classes/CrawlStrategy/SubProcessExecutionStrategy.php
-
-		-
-			message:
-				"""
-					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
-					since TYPO3 10\\.4, will be removed in version 12\\.0$#
-				"""
-			count: 1
-			path: Classes/Domain/Model/Process.php
 
 		-
 			message:
@@ -536,15 +473,6 @@ parameters:
 		-
 			message:
 				"""
-					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
-					since TYPO3 10\\.4, will be removed in version 12\\.0$#
-				"""
-			count: 2
-			path: Classes/Hooks/ProcessCleanUpHook.php
-
-		-
-			message:
-				"""
 					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
 					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
 				"""
@@ -571,15 +499,6 @@ parameters:
 				"""
 					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:
 					Use fetchNumeric\\(\\), fetchAssociative\\(\\) or fetchOne\\(\\) instead\\.$#
-				"""
-			count: 1
-			path: Classes/Service/ConfigurationService.php
-
-		-
-			message:
-				"""
-					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
-					since TYPO3 10\\.4, will be removed in version 12\\.0$#
 				"""
 			count: 1
 			path: Classes/Service/ConfigurationService.php
@@ -648,15 +567,6 @@ parameters:
 			message: "#^Possibly invalid array key type \\(array\\|string\\)\\.$#"
 			count: 3
 			path: Classes/Service/ConfigurationService.php
-
-		-
-			message:
-				"""
-					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
-					since TYPO3 10\\.4, will be removed in version 12\\.0$#
-				"""
-			count: 1
-			path: Classes/Service/ProcessService.php
 
 		-
 			message:


### PR DESCRIPTION
This PRs switched from ObjectManager->get() to GeneralUtility::makeInstace, as preparing for the switch to the Dependency Injection. 

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
