### PR TITLE
Updated descriptions of command options

### DIFF
--- a/Classes/Command/ProcessQueueCommand.php
+++ b/Classes/Command/ProcessQueueCommand.php
@@ -149,7 +149,7 @@ class ProcessQueueCommand extends Command
             'sleepafter',
             '',
             InputOption::VALUE_OPTIONAL,
-            'Amount of milliseconds which the system should use to relax between crawls',
+            'Amount of seconds which the system should use to relax after all crawls are done',
             '0'
         );
 
@@ -157,7 +157,7 @@ class ProcessQueueCommand extends Command
             'sleeptime',
             '',
             InputOption::VALUE_OPTIONAL,
-            'Amount of seconds which the system should use to relax after all crawls are done.'
+            'Amount of microseconds which the system should use to relax between crawls'
         );
     }
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -25,7 +25,7 @@ enableTimeslot=1
 ## Processing
 #########
 
-# cat=Processing; type=int [0-10000]; label= Sleep time between requests: Time in milliseconds the crawler should sleep between requesting urls: low = faster / high = less stress for the server
+# cat=Processing; type=int [0-10000]; label= Sleep time between requests: Time in microseconds the crawler should sleep between requesting urls: low = faster / high = less stress for the server
 sleepTime = 1000
 
 # cat=Processing; type=int [0-100]; label= Sleep time after finishing: Time in seconds the crawler should sleep before finishing


### PR DESCRIPTION
The descriptions for sleeptime and sleepafter where swapped (related to #515).
The unit for sleeptime is microseconds (used in usleep) not milliseconds (fixed in Command description and ext_conf_template.txt).