### PR TITLE
Remove break after return in example

### DIFF
--- a/Documentation/Configuration/Examples/News/Index.rst
+++ b/Documentation/Configuration/Examples/News/Index.rst
@@ -122,23 +122,19 @@ and register a signal slot in your site package.
          $numOfDemandedCategories = \count($demandedCategories);
          $intersection = \array_intersect($itemCategoryIds, $demandedCategories);
          $numOfCommonItems = \count($intersection);
+
          switch ($categoryConjunction) {
                case 'AND':
                   return $numOfCommonItems === $numOfDemandedCategories;
-                  break;
                case 'OR':
                   return $numOfCommonItems > 0;
-                  break;
                case 'NOTAND':
                   return $numOfCommonItems < $numOfDemandedCategories;
-                  break;
                case 'NOTOR':
                   return $numOfCommonItems === 0;
-                  break;
-               default:
-                  return true;
-                  break;
          }
+
+         return true;
       }
     }
 


### PR DESCRIPTION
A return terminates execution immediately so no further code is reached and executed.

## Description

<!-- What does this PR do -->

<!-- Does this solve an existing issue, then please reference with #issue-number -->

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
