### PR TITLE
Check for ps command before executing it

### DIFF
--- a/Classes/Hooks/ProcessCleanUpHook.php
+++ b/Classes/Hooks/ProcessCleanUpHook.php
@@ -192,7 +192,15 @@ class ProcessCleanUpHook implements CrawlerHookInterface
         $returnArray = [];
         if (! Environment::isWindows()) {
             // Not windows
-            exec('ps aux | grep \'typo3 crawler:processQueue\'', $returnArray, $returnValue);
+            if (`which ps`) {
+                // ps command is defined
+                exec('ps aux | grep \'typo3 crawler:processQueue\'', $returnArray, $returnValue);
+            } else {
+                trigger_error(
+                    'Crawler is unable to locate the ps command to clean up orphaned crawler processes.',
+                    E_USER_WARNING
+                );
+            }
         } else {
             // Windows
             exec('tasklist | find \'typo3 crawler:processQueue\'', $returnArray, $returnValue);

--- a/Documentation/Configuration/Examples/News/Index.rst
+++ b/Documentation/Configuration/Examples/News/Index.rst
@@ -42,7 +42,7 @@ another page. In this case it would still be possible to view news of category A
 the detail page for category B (example.com/detail-page-for-category-B/news-of-category-A).
 That means that each news article would be crawled twice - once on the detail page
 for category A and once on the detail page for category B. It is possible to use a
-signal slot within news to prevent this.
+PSR-14 event with news to prevent this.
 
 On both detail pages include this typoscript setup:
 ::
@@ -56,32 +56,21 @@ On both detail pages include this typoscript setup:
         detail.errorHandling = pageNotFoundHandler
     }
 
-and register a signal slot in your site package.
+and register an event listener in your site package.
 
-:file:`ext/ext_localconf.php`
+:file:`ext/Configuration/Services.yaml`
 
-.. code-block:: php
+.. code-block:: yaml
 
-    <?php
+   services:
+     Vendor\Ext\EventListeners\NewsDetailEventListener:
+       tags:
+         - name: event.listener
+           identifier: 'myNewsDetailListener'
+           event: GeorgRinger\News\Event\NewsDetailActionEvent
 
-    defined('TYPO3_MODE') or die();
 
-    (function() {
-         if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('news') === true) {
-            $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-               TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class
-            );
-            $signalSlotDispatcher->connect(
-               GeorgRinger\News\Controller\NewsController::class,
-               'detailAction',
-               Vendor\Ext\Slots\NewsDetailSlot::class,
-               'detailActionSlot',
-               true
-            );
-        }
-    })();
-
-:file:`ext/Classes/Slots/NewsDetailSlot.php`
+:file:`ext/Classes/EventListeners/NewsDetailEventListener.php`
 
 .. code-block:: php
 
@@ -89,53 +78,51 @@ and register a signal slot in your site package.
 
     declare(strict_types=1);
 
-    namespace Vendor\Ext\Slots;
+    namespace Vendor\Ext\EventListeners;
 
-    class NewsDetailSlot
+    use GeorgRinger\News\Event\NewsDetailActionEvent;
+
+    class NewsDetailEventListener
     {
-      public function detailActionSlot($newsItem, $currentPage, $demand, $settings, $extendedVariables): array
-      {
-         if (!\is_null($newsItem)) {
-               $demandedCategories = $demand->getCategories();
-               $itemCategories = $newsItem->getCategories()->toArray();
-               $itemCategoryIds = \array_map(function($category) {
-                  return (string)$category->getUid();
-               }, $itemCategories);
-               /**
-                * Unset the news article if necessary, which - in conjunction with the above TypoScript - will cause a 404 error
-                */
-               if (count($demandedCategories) > 0 && !$this->itemMatchesCategoryDemand($settings['categoryConjunction'], $itemCategoryIds, $demandedCategories)) {
-                  $newsItem = null;
-               }
-         }
-         return [
-               'newsItem' => $newsItem,
-               'currentPage' => $currentPage,
-               'demand' => $demand,
-               'settings' => $settings,
-               'extendedVariables' => $extendedVariables,
-         ];
-      }
+       public function __invoke(NewsDetailActionEvent $event): void
+       {
+          $assignedValues = $event->getAssignedValues();
+          $newsItem = $assignedValues['newsItem'];
+          $demand = $assignedValues['demand'];
+          $settings = $assignedValues['settings'];
 
-      protected function itemMatchesCategoryDemand(string $categoryConjunction, array $itemCategoryIds, array $demandedCategories): bool
-      {
-         $numOfDemandedCategories = \count($demandedCategories);
-         $intersection = \array_intersect($itemCategoryIds, $demandedCategories);
-         $numOfCommonItems = \count($intersection);
+          if (!\is_null($newsItem)) {
+             $demandedCategories = $demand->getCategories();
+             $itemCategories = $newsItem->getCategories()->toArray();
+             $itemCategoryIds = \array_map(function($category) {
+                return (string)$category->getUid();
+             }, $itemCategories);
 
-         switch ($categoryConjunction) {
-               case 'AND':
-                  return $numOfCommonItems === $numOfDemandedCategories;
-               case 'OR':
-                  return $numOfCommonItems > 0;
-               case 'NOTAND':
-                  return $numOfCommonItems < $numOfDemandedCategories;
-               case 'NOTOR':
-                  return $numOfCommonItems === 0;
-         }
+             if (count($demandedCategories) > 0 && !$this::itemMatchesCategoryDemand($settings['categoryConjunction'], $itemCategoryIds, $demandedCategories)) {
+                $assignedValues['newsItem'] = null;
+                $event->setAssignedValues($assignedValues);
+             }
+          }
+       }
 
-         return true;
-      }
+       protected static function itemMatchesCategoryDemand(string $categoryConjunction, array $itemCategoryIds, array $demandedCategories): bool
+       {
+          $numOfDemandedCategories = \count($demandedCategories);
+          $intersection = \array_intersect($itemCategoryIds, $demandedCategories);
+          $numOfCommonItems = \count($intersection);
+
+          switch ($categoryConjunction) {
+                case 'AND':
+                   return $numOfCommonItems === $numOfDemandedCategories;
+                case 'OR':
+                   return $numOfCommonItems > 0;
+                case 'NOTAND':
+                   return $numOfCommonItems < $numOfDemandedCategories;
+                case 'NOTOR':
+                   return $numOfCommonItems === 0;
+          }
+          return true;
+       }
     }
 
 .. warning::


### PR DESCRIPTION
## Description
This PR adds a simple check to see whether the `ps` command can be found before actually executing it in the ProcessCleanUpHook. While this PR does not add any functionality to use alternative methods to find orphaned crawler processes, it does prevent the hook from throwing an exception if the `ps` command can not be found.

See: #758 .

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
