### PR TITLE
[TASK] Adjust minimum TYPO3 version to v11.5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "psr/log": "^1.0",
         "symfony/console": "^5.0",
         "typo3/cms-backend": "*",
-        "typo3/cms-core": "^11.5 || ^12.0",
+        "typo3/cms-core": "^11.5.6 || ^12.0",
         "typo3/cms-frontend": "*",
         "typo3/cms-info": "*",
         "typo3/cms-seo": "*"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '11.0.4',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-11.5.99',
+            'php' => '8.0.0-8.99.99',
+            'typo3' => '11.5.6-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
## Description

QueryBuilder->executeQuery() and ->executeStatement() were introduced on Jan 18th, 2022 with
https://github.com/TYPO3/typo3/commit/0d4fff93b5cf378357b9bfc1144d47df4787a1fc. The first
release providing the new methods was TYPO3 v11.5.6 on Feb 8th, 2022. As the main branch
of EXT:crawler now use these methods since https://github.com/tomasnorre/crawler/commit/9a04f114ffad9eac8b7ec7b4f800890225a2caa6, 
the minimum TYPO3 version is adjusted.

Additionally, as the minimum PHP version is now 8.0, but TYPO3 v11.5 can also be installed on
PHP 7.4, the PHP version constraint is added to ext_emconf.php.