### PR TITLE
Support environment variables as base_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog TYPO3 Crawler
 
+### Added
+* Support for environment variables as base_url
+
 ## Crawler 11.0.4
 Crawler 11.0.4 was released on January 28th, 2022
 

--- a/Classes/Backend/RequestForm/LogRequestForm.php
+++ b/Classes/Backend/RequestForm/LogRequestForm.php
@@ -146,7 +146,7 @@ final class LogRequestForm extends AbstractRequestForm implements RequestFormInt
             // Show details:
             if ($queueId) {
                 // Get entry record:
-                $q_entry = $this->queryBuilder
+                $result = $this->queryBuilder
                     ->from(QueueRepository::TABLE_NAME)
                     ->select('*')
                     ->where(
@@ -154,11 +154,11 @@ final class LogRequestForm extends AbstractRequestForm implements RequestFormInt
                     )
                     ->execute();
 
-                if (!$q_entry instanceof Result) {
+                if (!$result instanceof Result) {
                     throw new Exception('Could not find Queue entry', 1665559362);
                 }
 
-                $q_entry = $q_entry->fetch();
+                $q_entry = $result->fetch();
 
                 // Explode values
                 $q_entry['parameters'] = $this->jsonCompatibilityConverter->convert($q_entry['parameters']);

--- a/Classes/Backend/RequestForm/LogRequestForm.php
+++ b/Classes/Backend/RequestForm/LogRequestForm.php
@@ -12,7 +12,6 @@ use AOE\Crawler\Utility\MessageUtility;
 use AOE\Crawler\Value\QueueFilter;
 use AOE\Crawler\Writer\FileWriter\CsvWriter\CrawlerCsvWriter;
 use AOE\Crawler\Writer\FileWriter\CsvWriter\CsvWriterInterface;
-use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\ForwardCompatibility\Result;
 use Doctrine\DBAL\Query\QueryBuilder;
 use TYPO3\CMS\Backend\Tree\View\PageTreeView;

--- a/Classes/Service/UrlService.php
+++ b/Classes/Service/UrlService.php
@@ -81,6 +81,9 @@ class UrlService
             }
             $url = $site->getRouter()->generateUri($pageId, $queryParts);
             if (!empty($alternativeBaseUrl)) {
+                if (strpos($alternativeBaseUrl, '$') === 0) {
+                    $alternativeBaseUrl = getenv(substr($alternativeBaseUrl, 1));
+                }
                 $alternativeBaseUrl = new Uri($alternativeBaseUrl);
                 $url = $url->withHost($alternativeBaseUrl->getHost());
                 $url = $url->withScheme($alternativeBaseUrl->getScheme());

--- a/Classes/Service/UrlService.php
+++ b/Classes/Service/UrlService.php
@@ -82,7 +82,7 @@ class UrlService
             $url = $site->getRouter()->generateUri($pageId, $queryParts);
             if (!empty($alternativeBaseUrl)) {
                 if (strpos($alternativeBaseUrl, '$') === 0) {
-                    $alternativeBaseUrl = getenv(substr($alternativeBaseUrl, 1));
+                    $alternativeBaseUrl = getenv(substr($alternativeBaseUrl, 1)) ?: '';
                 }
                 $alternativeBaseUrl = new Uri($alternativeBaseUrl);
                 $url = $url->withHost($alternativeBaseUrl->getHost());

--- a/Classes/Service/UrlService.php
+++ b/Classes/Service/UrlService.php
@@ -81,7 +81,7 @@ class UrlService
             }
             $url = $site->getRouter()->generateUri($pageId, $queryParts);
             if (!empty($alternativeBaseUrl)) {
-                if (strpos($alternativeBaseUrl, '$') === 0) {
+                if (str_starts_with($alternativeBaseUrl, '$')) {
                     $alternativeBaseUrl = getenv(substr($alternativeBaseUrl, 1)) ?: '';
                 }
                 $alternativeBaseUrl = new Uri($alternativeBaseUrl);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -58,12 +58,7 @@ parameters:
 			path: Classes/Backend/RequestForm/LogRequestForm.php
 
 		-
-			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\.$#"
-			count: 1
-			path: Classes/Backend/RequestForm/LogRequestForm.php
-
-		-
-			message: "#^Class cognitive complexity is 71, keep it under 60$#"
+			message: "#^Class cognitive complexity is 72, keep it under 60$#"
 			count: 1
 			path: Classes/Backend/RequestForm/LogRequestForm.php
 


### PR DESCRIPTION
To allow a crawler configuration on a per-instance basis, it would be nice to use an environment variable as alternative base_url, e.g. $TYPO3_RELEASE_URL