### PR TITLE
[CI] Switch to actions/checkout@v3

### DIFF
--- a/.github/workflows/Acceptance.yml
+++ b/.github/workflows/Acceptance.yml
@@ -39,7 +39,7 @@ jobs:
           php -v
           composer --version
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: jonaseberle/github-action-setup-ddev@v1
         with:
           ddevDir: ".devbox"
@@ -109,7 +109,7 @@ jobs:
           php -v
           composer --version
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: |
           cd .devbox/.ddev
           docker-compose -f docker-compose.selenium.yaml up -d

--- a/.github/workflows/BackwardCompatibilityCheck.yml
+++ b/.github/workflows/BackwardCompatibilityCheck.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 0
 

--- a/.github/workflows/Coveralls.yml
+++ b/.github/workflows/Coveralls.yml
@@ -21,7 +21,7 @@ jobs:
           mysql root password: 'root'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PHP Version 8.0
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/DBMS.yml
+++ b/.github/workflows/DBMS.yml
@@ -24,7 +24,7 @@ jobs:
           docker run -e POSTGRES_DB=typo3 -e POSTGRES_USER=root -e POSTGRES_PASSWORD=root -d -p 5432:5432 postgres:${{ matrix.postgres }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PHP Version ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
@@ -67,7 +67,7 @@ jobs:
         typo3: [ '11.5' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PHP Version ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
@@ -104,7 +104,7 @@ jobs:
           mysql root password: 'root'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PHP Version ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
@@ -145,7 +145,7 @@ jobs:
           mysql root password: 'root'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PHP Version ${{ matrix.php }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -9,7 +9,7 @@ jobs:
   TER:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - uses: actions/cache@v1

--- a/.github/workflows/GithubServer.yml.txt
+++ b/.github/workflows/GithubServer.yml.txt
@@ -29,7 +29,7 @@ jobs:
         run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/MutationTests.yml
+++ b/.github/workflows/MutationTests.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 0
 

--- a/.github/workflows/Requirement.yml
+++ b/.github/workflows/Requirement.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check Requirements
     runs-on: ubuntu-latest
     steps:
-      -   uses: actions/checkout@v2
+      -   uses: actions/checkout@v3
       -   id: composer-cache
           run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       -   uses: actions/cache@v1

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -15,7 +15,7 @@ jobs:
       -   name: Start database server
           run: sudo /etc/init.d/mysql start
 
-      -   uses: actions/checkout@v2
+      -   uses: actions/checkout@v3
       -   id: composer-cache
           run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       -   uses: actions/cache@v1

--- a/.github/workflows/StaticAnalysis.yaml
+++ b/.github/workflows/StaticAnalysis.yaml
@@ -13,7 +13,7 @@ jobs:
         name: PHPstan
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
             -   id: composer-cache
                 run: echo "::set-output name=dir::$(composer config cache-files-dir)"
             -   uses: actions/cache@v1
@@ -33,7 +33,7 @@ jobs:
         name: Rector
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
             -   id: composer-cache
                 run: echo "::set-output name=dir::$(composer config cache-files-dir)"
             -   uses: actions/cache@v1
@@ -53,7 +53,7 @@ jobs:
         name: Code Style
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
             -   id: composer-cache
                 run: echo "::set-output name=dir::$(composer config cache-files-dir)"
             -   uses: actions/cache@v1
@@ -73,7 +73,7 @@ jobs:
         name: Psalm
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
             -   id: composer-cache
                 run: echo "::set-output name=dir::$(composer config cache-files-dir)"
             -   uses: actions/cache@v1

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -31,7 +31,7 @@ jobs:
           mysql root password: 'root'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PHP Version ${{ matrix.php }}
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Description

This updates `actions/checkout` to `v3` as node 12 is deprecated.
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

<!-- Does this solve an existing issue, then please reference with #issue-number -->

**I have**

- [ ] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
