### PR TITLE
[BUGFIX] Check that array key is set before using (PHP 8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog TYPO3 Crawler
 
+## Crawler 11.0.7
+
+### Fixed
+* Ensure that array key is set before used in BuildQueueCommand (PHP 8.1)
+
+
 ## Crawler 11.0.6
 Crawler 11.0.6 was released on November 12th, 2022
 

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -190,7 +190,7 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
 
                 $progressBar->clear();
                 if (is_array($requestResult)) {
-                    $resLog = is_array($requestResult['log']) ? PHP_EOL . chr(9) . chr(9) . implode(PHP_EOL . chr(9) . chr(9), $requestResult['log']) : '';
+                    $resLog = array_key_exists('log', $requestResult) && is_array($requestResult['log']) ? PHP_EOL . chr(9) . chr(9) . implode(PHP_EOL . chr(9) . chr(9), $requestResult['log']) : '';
                     $output->writeln('<info>OK: ' . $resLog . '</info>' . PHP_EOL);
                 } else {
                     $output->writeln('<error>Error checking Crawler Result:  ' . substr(preg_replace('/\s+/', ' ', strip_tags($resultContent)), 0, 30000) . '...' . PHP_EOL . '</error>' . PHP_EOL);


### PR DESCRIPTION
## Description

Ensures that array key is set before used.

Resolves #984 

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
