### PR TITLE
[BUGFIX] #989: Fixes PHP 8.1 transOrigPointerField warning

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -442,7 +442,7 @@ class ConfigurationService
                 // TODO: Check if this works as intended!
                 $queryBuilder->add('from', $addTable);
             }
-            $transOrigPointerField = $GLOBALS['TCA'][$subpartParams['_TABLE']]['ctrl']['transOrigPointerField'];
+            $transOrigPointerField = $GLOBALS['TCA'][$subpartParams['_TABLE']]['ctrl']['transOrigPointerField'] ?? false;
 
             if (($subpartParams['_ENABLELANG'] ?? false) && $transOrigPointerField) {
                 $queryBuilder->andWhere($queryBuilder->expr()->lte($transOrigPointerField, 0));


### PR DESCRIPTION
Fixes the PHP 8.1 warning when "transOrigPointerField" doesn't exist in TCA for the given table

## Description

This PR fixes #989 

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
