### PR TITLE
[ENHANCEMENT] Use newer curly brace syntax for string literals

### DIFF
--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -129,9 +129,9 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
 
         $pageId = MathUtility::forceIntegerInRange((int) $input->getArgument('page'), 0);
         if ($pageId === 0) {
-            $message = "Page ${pageId} is not a valid page, please check you root page id and try again.";
+            $message = "Page {$pageId} is not a valid page, please check you root page id and try again.";
             MessageUtility::addErrorMessage($message);
-            $output->writeln("<info>${message}</info>");
+            $output->writeln("<info>{$message}</info>");
             return Command::FAILURE;
         }
 


### PR DESCRIPTION
## Description

Replaces all occurrences of the "${var}" syntax in string literals with "{$var}" syntax, wherever I could find it. I literally just used VSCode's find and replace on PHP files.

See [#1007](https://github.com/tomasnorre/crawler/issues/1007)

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
