### PR TITLE
[BUGFIX] Prevent undefined array key uid and username in FrontendUserAuthentication

### DIFF
--- a/Classes/Middleware/FrontendUserAuthenticator.php
+++ b/Classes/Middleware/FrontendUserAuthenticator.php
@@ -127,6 +127,8 @@ class FrontendUserAuthenticator implements MiddlewareInterface
         /** @var FrontendUserAuthentication $frontendUser */
         $frontendUser = $request->getAttribute('frontend.user');
         $frontendUser->user[$frontendUser->usergroup_column] = '0,-2,' . $grList;
+        $frontendUser->user[$frontendUser->userid_column] = 0;
+        $frontendUser->user[$frontendUser->username_column] = '';
         $frontendUser->fetchGroupData($request);
         $frontendUser->user['uid'] = PHP_INT_MAX;
         return $frontendUser;


### PR DESCRIPTION
## Description

Prevents undefined array key uid and username warnings in FrontendUserAuthentication middleware.
Resolves #1012 which blows up the sys_log on every requested login protected page in queue. 
Perhaps not the cleanest solution.

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code