### PR TITLE
[BUGFIX] Change tense in flush command message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * If indexed_search is installed activate procInstructions for indexed_search
 * Prevent undefined array key uid and username in FrontendUserAuthentication
 * Fix loading middleware order to make forced indexing work again [@cweiske](https://github.com/cweiske)
+* Change tense in flush command message [@cweiske](https://github.com/cweiske)
 
 ### Deprecated
 #### Classes

--- a/Classes/Command/FlushQueueCommand.php
+++ b/Classes/Command/FlushQueueCommand.php
@@ -76,13 +76,13 @@ It will remove queue entries and perform a cleanup.' . chr(10) . chr(10) .
         switch ($queueFilter) {
             case 'all':
                 $queueRepository->flushQueue($queueFilter);
-                $output->writeln('<info>All entries in Crawler queue will be flushed</info>');
+                $output->writeln('<info>All entries in Crawler queue have been flushed</info>');
                 break;
             case 'finished':
             case 'pending':
                 $queueRepository->flushQueue($queueFilter);
                 $output->writeln(
-                    '<info>All entries in Crawler queue, with status: "' . $queueFilter . '" will be flushed</info>'
+                    '<info>All entries in Crawler queue with status "' . $queueFilter . '" have been flushed</info>'
                 );
                 break;
             default:

--- a/Tests/Functional/Command/FlushQueueCommandTest.php
+++ b/Tests/Functional/Command/FlushQueueCommandTest.php
@@ -71,17 +71,17 @@ class FlushQueueCommandTest extends FunctionalTestCase
     {
         yield 'Flush All' => [
             'mode' => 'all',
-            'expectedOutput' => 'All entries in Crawler queue will be flushed',
+            'expectedOutput' => 'All entries in Crawler queue have been flushed',
             'expectedCount' => 0,
         ];
         yield 'Flush Pending' => [
             'mode' => 'pending',
-            'expectedOutput' => 'All entries in Crawler queue, with status: "pending" will be flushed',
+            'expectedOutput' => 'All entries in Crawler queue with status "pending" have been flushed',
             'expectedCount' => 7,
         ];
         yield 'Flush Finished' => [
             'mode' => 'finished',
-            'expectedOutput' => 'All entries in Crawler queue, with status: "finished" will be flushed',
+            'expectedOutput' => 'All entries in Crawler queue with status "finished" have been flushed',
             'expectedCount' => 8,
         ];
     }


### PR DESCRIPTION
.. the repository has already been flushed already when the message is shown. No need to say it "will be" flushed in the future.

## Description

The time form in the flush command status message is wrong:
```
$ ./vendor/bin/typo3cms crawler:flushQueue all
All entries in Crawler queue will be flushed
```

The repository already deleted the data when the message is shown.

This PR changes the message to past tense to indicate this.


**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working (I hope CI does)
- [x] Added description to CHANGELOG.md

