### PR TITLE
[BUGFIX] Fix middleware order for forced indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Fixed
 * If indexed_search is installed activate procInstructions for indexed_search
 * Prevent undefined array key uid and username in FrontendUserAuthentication
+* Fix loading middleware order to make forced indexing work again [@cweiske](https://github.com/cweiske)
 
 ### Deprecated
 #### Classes

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -14,7 +14,7 @@ return [
         ],
         'aoe/crawler/initialization' => [
             'target' => CrawlerInitialization::class,
-            'before' => ['typo3/cms-core/normalizedParams'],
+            'before' => ['typo3/cms-frontend/prepare-tsfe-rendering'],
         ],
     ],
 ];


### PR DESCRIPTION
History:
--------
Because of a problem with lochmueller/staticfilecache, crawler issue https://github.com/tomasnorre/crawler/issues/642 changed the middleware loading order to execute crawler after static file cache. (commit 0f7cb6abac4d8d6e228b0385665dc02f17cdfdcb)

The source of the problem was that the crawler CrawlerInitialization middleware overwrote the HTTP response that was generated by TYPO3.

Since commit 8a9b896721f479d7babc4bb5920536e8124a1797 (issue https://github.com/tomasnorre/crawler/issues/837, version 11.0.1) the HTTP response is not destroyed/overwritten by crawler anymore but moved into a HTTP header "X-T3Crawler-Meta".
The loading order does not influence compatibility with static file cache anymore.

Bug
---
The changed loading order in the bug fix led to the problem that
> indexed_search:TypoScriptFrontendHook
was executed before
> crawler:CrawlerInitialization

But CrawlerInitialization must be run before TypoScriptFrontendHook because it loads request data that are needed by indexed_search.

This led to bug https://github.com/tomasnorre/crawler/issues/729
- forced reindexing by the crawler did not work anymore if the page was already in cache.

Solution
--------
Restore the HTTP middleware loading order as it was before the fix for #642, so that the code path is again:

1. crawler:FrontendUserAuthenticator (aoe/crawler/authentication)

2. crawler:CrawlerInitialization (aoe/crawler/initialization)

3. indexed_search:TypoScriptFrontendHook (called by typo3/cms-frontend/prepare-tsfe-rendering)

Resolves: https://github.com/tomasnorre/crawler/issues/729

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working (no, I hope CI does that)
- [x] Added description to CHANGELOG.md (github-handle is optional)
