### PR TITLE
[BUGFIX] Fix middleware order for forced indexing (crawler 11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog TYPO3 Crawler
 
+## Crawler 11.0.8-dev
+### Fixed
+* Fix loading middleware order to make forced indexing work again [@cweiske](https://github.com/cweiske)
+
 ## Crawler 11.0.7
 Crawler 11.0.7 was released on November 18th, 2022
 

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -19,7 +19,7 @@ return [
         'aoe/crawler/initialization' => [
             'target' => CrawlerInitialization::class,
             'before' => [
-                'typo3/cms-core/normalizedParams',
+                'typo3/cms-frontend/prepare-tsfe-rendering',
             ],
         ],
     ],


### PR DESCRIPTION
(Backport of #1018 to v11.x)

History:
--------
Because of a problem with lochmueller/staticfilecache, crawler issue https://github.com/tomasnorre/crawler/issues/642 changed the middleware loading order to execute crawler after static file cache. (commit 0f7cb6abac4d8d6e228b0385665dc02f17cdfdcb)

The source of the problem was that the crawler CrawlerInitialization middleware overwrote the HTTP response that was generated by TYPO3.

Since commit 8a9b896721f479d7babc4bb5920536e8124a1797 (issue https://github.com/tomasnorre/crawler/issues/837) the HTTP response is not destroyed/overwritten by crawler anymore but moved into a HTTP header "X-T3Crawler-Meta".
The loading order does not influence compatibility with static file cache anymore.

Bug
---
The changed loading order in the bug fix led to the problem that
> indexed_search:TypoScriptFrontendHook
was executed before
> crawler:CrawlerInitialization

But CrawlerInitialization must be run before TypoScriptFrontendHook because it loads request data that are needed by indexed_search.

This led to bug https://github.com/tomasnorre/crawler/issues/729
- forced reindexing by the crawler did not work anymore if the page was already in cache.

Solution
--------
Restore the HTTP middleware loading order as it was before the fix for #642, so that the code path is again:

1. crawler:FrontendUserAuthenticator (aoe/crawler/authentication)

2. crawler:CrawlerInitialization (aoe/crawler/initialization)

3. indexed_search:TypoScriptFrontendHook (called by typo3/cms-frontend/prepare-tsfe-rendering)

Resolves: https://github.com/tomasnorre/crawler/issues/729
