### PR TITLE
Fix deprecation notice in BuildQueueCommand.php

### DIFF
--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -129,9 +129,9 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
 
         $pageId = MathUtility::forceIntegerInRange((int) $input->getArgument('page'), 0);
         if ($pageId === 0) {
-            $message = "Page ${pageId} is not a valid page, please check you root page id and try again.";
+            $message = "Page {$pageId} is not a valid page, please check you root page id and try again.";
             MessageUtility::addErrorMessage($message);
-            $output->writeln("<info>${message}</info>");
+            $output->writeln("<info>{$message}</info>");
             return Command::FAILURE;
         }
 


### PR DESCRIPTION
## Description

The following deprecation warning frequently occurred when using PHP8.2

PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead

This PR fixes this deprecation notice.

See also: https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

<!-- What does this PR do -->

<!-- Does this solve an existing issue, then please reference with #issue-number -->

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
