### PR TITLE
[TASK] Avoid deprecations in PHP 8.2 (v11.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Crawler 11.0.8-dev
 ### Fixed
 * Fix loading middleware order to make forced indexing work again [@cweiske](https://github.com/cweiske)
+* Avoid deprecations in PHP 8.2
 
 ## Crawler 11.0.7
 Crawler 11.0.7 was released on November 18th, 2022

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -134,9 +134,9 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
 
         $pageId = MathUtility::forceIntegerInRange((int) $input->getArgument('page'), 0);
         if ($pageId === 0) {
-            $message = "Page ${pageId} is not a valid page, please check you root page id and try again.";
+            $message = "Page {$pageId} is not a valid page, please check you root page id and try again.";
             MessageUtility::addErrorMessage($message);
-            $output->writeln("<info>${message}</info>");
+            $output->writeln("<info>{$message}</info>");
             return 1;
         }
 


### PR DESCRIPTION
## Description

Fix deprecation warnings occurring with PHP >= 8.2

Solves #1011 and #1007 for v11.x branch.
PR for main branch also available #999.

NOTE: I split the CHANGELOG.md change to a separate commit on purpose to allow using the actual changes as patch with `cweagans/composer-patches`.
Feel free to squash the commits when merging the PR!

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
