### PR TITLE
fix 'invalid omit_containers'

### DIFF
--- a/.devbox/.ddev/config.yaml
+++ b/.devbox/.ddev/config.yaml
@@ -26,7 +26,7 @@ hooks:
     - exec: /var/www/html/bin/typo3 cache:flush
     - exec: /var/www/html/bin/typo3 cache:warmup
     - exec: /var/www/html/bin/typo3 backend:unlock
-omit_containers: [ dba, ddev-ssh-agent ]
+omit_containers: [ db, ddev-ssh-agent ]
 webimage_extra_packages: [ cron ]
 use_dns_when_possible: true
 timezone: Europe/Copenhagen

--- a/.devbox/.ddev/ddev.site/config.nodb.yaml
+++ b/.devbox/.ddev/ddev.site/config.nodb.yaml
@@ -1,0 +1,1 @@
+omit_containers: [ db, ddev-ssh-agent ]


### PR DESCRIPTION
## Description

<!-- What does this PR do -->
this commit tries to fix failing of `Run jonaseberle/github-action-setup-ddev@v1` in #1022, by defining containers to omit differently.

if the mentioned run above is working now the PR could be merged, else just dump it, or remove `db` in `omit_containers` from `.devbox/.ddev/config.yaml`.

Note, that the whole failing tests include still another issue, which is not addressed in this commit / PR.