### PR TITLE
[BUGFIX] Check queueRec before usage to avoid PHP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+* Check queueRec before usages to avoid php-errors
+
 ### Deprecated
 
 #### Classes

--- a/Classes/Middleware/FrontendUserAuthenticator.php
+++ b/Classes/Middleware/FrontendUserAuthenticator.php
@@ -105,6 +105,10 @@ class FrontendUserAuthenticator implements MiddlewareInterface
 
     private function isRequestHashMatchingQueueRecord(?array $queueRec, string $hash): bool
     {
+        if ($queueRec === null || !array_key_exists('qid', $queueRec) || !array_key_exists('set_id', $queueRec)) {
+            return false;
+        }
+
         return is_array($queueRec) && hash_equals(
             $hash,
             md5(


### PR DESCRIPTION
## Description

<!-- What does this PR do -->

Check if `$queueRec` is in a usable state

<!-- Does this solve an existing issue, then please reference with #issue-number -->

Resolves #1031 

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
