### PR TITLE
Fix: ProcessQueue throws truncated incorrect decimal value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+* Prevent exception `Truncated incorrect DECIMAL value` in `crawler:processQueue` [@xyng](https://github.com/xyng)
 
 ### Deprecated
 

--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -327,7 +327,7 @@ class QueueRepository extends Repository implements LoggerAwareInterface
                 $queryBuilder->expr()->eq('exec_time', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
                 $queryBuilder->expr()->in(
                     'process_id',
-                    $queryBuilder->createNamedParameter($processIds, ArrayParameterType::INTEGER)
+                    $queryBuilder->createNamedParameter($processIds, ArrayParameterType::STRING)
                 )
             )
             ->set('process_scheduled', '0')

--- a/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
@@ -134,7 +134,7 @@ class QueueRepositoryTest extends FunctionalTestCase
     public function countNonExecutedItemsByProcessReturnsInteger(): void
     {
         $process = new Process();
-        $process->setProcessId('1007');
+        $process->setProcessId('4b802fa4bd183156c47836ba9c79643b');
 
         self::assertSame(2, $this->subject->countNonExecutedItemsByProcess($process));
     }
@@ -273,7 +273,7 @@ class QueueRepositoryTest extends FunctionalTestCase
     {
         $unprocessedEntriesBefore = $this->subject->countAllPendingItems() - $this->subject->countAllAssignedPendingItems();
         self::assertSame(5, $unprocessedEntriesBefore);
-        $processIds = ['1007'];
+        $processIds = ['4b802fa4bd183156c47836ba9c79643b'];
         $this->subject->unsetProcessScheduledAndProcessIdForQueueEntries($processIds);
 
         $unprocessedEntriesAfter = $this->subject->countAllPendingItems() - $this->subject->countAllAssignedPendingItems();

--- a/Tests/Functional/Fixtures/tx_crawler_queue.csv
+++ b/Tests/Functional/Fixtures/tx_crawler_queue.csv
@@ -6,9 +6,9 @@
 ,1004,0,1,"asdfgh","","",0,0,"FirstConfiguration","","",0
 ,1005,0,0,"asdfgh","","",10,0,"SecondConfiguration","","",0
 ,1006,1006,2,"qwerty","","",0,0,"SecondConfiguration","","7b6919e533f334550b6f19034dfd2f81",123
-,1007,1007,0,"asdfgh","","",12,0,"SecondConfiguration","","",123
-,1008,1007,3,"asdfgh","","",0,0,"ThirdConfiguration","","",456
-,1009,1007,4,"asdfgh","","",0,0,"ThirdConfiguration","","",789
+,1007,"4b802fa4bd183156c47836ba9c79643b",0,"asdfgh","","",12,0,"SecondConfiguration","","",123
+,1008,"4b802fa4bd183156c47836ba9c79643b",3,"asdfgh","","",0,0,"ThirdConfiguration","","",456
+,1009,"4b802fa4bd183156c47836ba9c79643b",4,"asdfgh","","",0,0,"ThirdConfiguration","","",789
 ,1015,0,5,"dvorak","","",0,12,"FirstConfiguration","","",0
 ,1016,1016,16,"dvorak","","",10,1245,"ThirdConfiguration","","",0
 ,1017,1017,17,"dvorak","","",20,4321,"FirstConfiguration","","",0


### PR DESCRIPTION
## Description

<!-- What does this PR do -->
This PR provides a test and fix for #1082 - changes the param-type of `processId` in the prepared statement to `string` instead of `integer`, since the database field already uses `varchar(50)` and `ProcessQueueCommand` will pass a string.
That can lead to either non-matches (sqlite) or even runtime errors (in one of our environments using MariaDB).

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code

## Note

@tomasnorre I tried my best to get the test to reproduce. For some reason, only the SQLite one ran on my machine. For SQLite, there is no runtime error, but non-numeric values are not matched, leading the test case to fail the count-check which is somewhat sufficient to evaluate the problem.
I'd appreciate if you could check the MySQL and PostgreSQL derivates if they work correctly (either throw and exception or at least fail the count test).