### PR TITLE
Suppress E_WARNING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * Prevent exception `Truncated incorrect DECIMAL value` in `crawler:processQueue` [@xyng](https://github.com/xyng)
+* Prevent and suppress E_WARNING in JsonCompatibilityConverter [@ulrichmathes](https://github.com/ulrichmathes)
 
 ### Deprecated
 

--- a/Classes/Converter/JsonCompatibilityConverter.php
+++ b/Classes/Converter/JsonCompatibilityConverter.php
@@ -53,13 +53,9 @@ class JsonCompatibilityConverter
             return $decoded;
         }
 
-        try {
-            $deserialized = unserialize($dataString, [
-                'allowed_classes' => false,
-            ]);
-        } catch (\Throwable) {
-            return false;
-        }
+        $deserialized = @unserialize($dataString, [
+            'allowed_classes' => false,
+        ]);
 
         if (is_object($deserialized)) {
             throw new \RuntimeException('Objects are not allowed: ' . var_export($deserialized, true), 1_593_758_307);

--- a/Classes/Converter/JsonCompatibilityConverter.php
+++ b/Classes/Converter/JsonCompatibilityConverter.php
@@ -38,6 +38,10 @@ class JsonCompatibilityConverter
      */
     public function convert(string $dataString): array|bool
     {
+        if (empty($dataString)) {
+            return false;
+        }
+
         $decoded = '';
         try {
             $decoded = json_decode($dataString, true, 512, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
- **[BUGFIX] don't convert empty string**
- **[BUGFIX] suppress unserialize E_WARNINGS**

## Description

Solves #1087

Prevents E_WANRINGS in JsonCompatibilityConverter
by early return on empty strings and fixing
the error handling of unserialize

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working [unit, functional are not running in devbox?]
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
