### PR TITLE
BUGFIX: Typecast PageTS Crawler Configuration force_ssl to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 * Prevent exception `Truncated incorrect DECIMAL value` in `crawler:processQueue` [@xyng](https://github.com/xyng)
+* Typecast PageTS Crawler Configuration `force_ssl` to `int`
 
 ### Deprecated
 

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -237,7 +237,7 @@ class CrawlerController implements LoggerAwareInterface
                 $pageId,
                 $urlQuery,
                 $vv['subCfg']['baseUrl'] ?? null,
-                (int) $vv['subCfg']['force_ssl'] ?? 0
+                (int) ($vv['subCfg']['force_ssl'] ?? 0)
             );
 
             if (!$url instanceof UriInterface) {

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -237,7 +237,7 @@ class CrawlerController implements LoggerAwareInterface
                 $pageId,
                 $urlQuery,
                 $vv['subCfg']['baseUrl'] ?? null,
-                $vv['subCfg']['force_ssl'] ?? 0
+                (int) $vv['subCfg']['force_ssl'] ?? 0
             );
 
             if (!$url instanceof UriInterface) {

--- a/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
+++ b/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
@@ -135,6 +135,19 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
    Description
          List of Page Ids to limit this configuration to
 
+.. container:: table-row
+
+   Property
+         .. _crawler-tsconfig-paramSets-key-force_ssl:
+
+         paramSets.[key].force_ssl
+
+   Data type
+         integer
+
+   Description
+         Whether https should be inforced or not. 0 = false (default), 1 = true.
+
 
 .. container:: table-row
 
@@ -183,5 +196,6 @@ Example
       procInstrFilter = tx_indexedsearch_reindex
       pidsOnly = 1,5,13,55
       userGroups = 1
+      force_ssl = 1
    }
 


### PR DESCRIPTION
## Description

This typecasts force_ssl to int PageTS Crawler Configurations.
Resolves #1000 

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
