### PR TITLE
Deprecate: CrawlerObjectException and TimeStampException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 ### Deprecated
 
 #### Classes
+* CrawlerObjectException
+* TimeStampException
 
 #### Functions & Properties
 

--- a/Classes/Exception/CrawlerObjectException.php
+++ b/Classes/Exception/CrawlerObjectException.php
@@ -21,6 +21,7 @@ namespace AOE\Crawler\Exception;
 
 /**
  * @internal since v12.0.0
+ * @deprecated since 12.0.5 will be removed in v14.x
  */
 class CrawlerObjectException extends \Exception
 {

--- a/Classes/Exception/TimeStampException.php
+++ b/Classes/Exception/TimeStampException.php
@@ -21,6 +21,7 @@ namespace AOE\Crawler\Exception;
 
 /**
  * @internal since v12.0.0
+ * @deprecated since 12.0.5 will be removed in v14.x
  */
 class TimeStampException extends \Exception
 {


### PR DESCRIPTION
## Description
Deprecates CrawlerObjectException and TimeStampException

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
