### PR TITLE
BUGFIX: Typecast PageTS Crawler Configuration force_ssl to int

### DIFF
--- a/.github/workflows/BackwardCompatibilityCheck.yml
+++ b/.github/workflows/BackwardCompatibilityCheck.yml
@@ -48,5 +48,5 @@ jobs:
           # To ensure compability with the roave tool.
           composer remove --dev nimut/typo3-complete nimut/testing-framework rector/rector symplify/easy-coding-standard typo3/testing-framework
           rm -rf .Build composer.lock
-          composer require --dev roave/backward-compatibility-check:"6.0.x-dev"
-          .Build/bin/roave-backward-compatibility-check --to=v11.x
+          composer require --dev roave/backward-compatibility-check:"^6.4"
+          .Build/bin/roave-backward-compatibility-check --from=11.0.0

--- a/.github/workflows/BackwardCompatibilityCheck.yml
+++ b/.github/workflows/BackwardCompatibilityCheck.yml
@@ -49,4 +49,4 @@ jobs:
           composer remove --dev nimut/typo3-complete nimut/testing-framework rector/rector symplify/easy-coding-standard typo3/testing-framework
           rm -rf .Build composer.lock
           composer require --dev roave/backward-compatibility-check:"6.0.x-dev"
-          .Build/bin/roave-backward-compatibility-check --to=^11
+          .Build/bin/roave-backward-compatibility-check --to=v11.x

--- a/.github/workflows/BackwardCompatibilityCheck.yml
+++ b/.github/workflows/BackwardCompatibilityCheck.yml
@@ -49,4 +49,4 @@ jobs:
           composer remove --dev nimut/typo3-complete nimut/testing-framework rector/rector symplify/easy-coding-standard typo3/testing-framework
           rm -rf .Build composer.lock
           composer require --dev roave/backward-compatibility-check:"6.0.x-dev"
-          .Build/bin/roave-backward-compatibility-check
+          .Build/bin/roave-backward-compatibility-check --to=v11.x

--- a/.github/workflows/BackwardCompatibilityCheck.yml
+++ b/.github/workflows/BackwardCompatibilityCheck.yml
@@ -49,4 +49,4 @@ jobs:
           composer remove --dev nimut/typo3-complete nimut/testing-framework rector/rector symplify/easy-coding-standard typo3/testing-framework
           rm -rf .Build composer.lock
           composer require --dev roave/backward-compatibility-check:"6.0.x-dev"
-          .Build/bin/roave-backward-compatibility-check --to=v11.x
+          .Build/bin/roave-backward-compatibility-check --to=^11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * Fixed query building when using _ADDTABLE parameter [@hawkeye1909](https://github.com/hawkeye1909)
+* Typecast PageTS Crawler Configuration `force_ssl` to `int`
 
 ### Deprecated
 

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -319,7 +319,7 @@ class CrawlerController implements LoggerAwareInterface
                 $pageId,
                 $urlQuery,
                 $vv['subCfg']['baseUrl'] ?? null,
-                $vv['subCfg']['force_ssl'] ?? 0
+                (int) ($vv['subCfg']['force_ssl'] ?? 0)
             );
 
             if (! $url instanceof UriInterface) {

--- a/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
+++ b/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
@@ -139,6 +139,20 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
 .. container:: table-row
 
    Property
+         .. _crawler-tsconfig-paramSets-key-force_ssl:
+
+         paramSets.[key].force_ssl
+
+   Data type
+         integer
+
+   Description
+         Whether https should be inforced or not. 0 = false (default), 1 = true.
+
+
+.. container:: table-row
+
+   Property
          .. _crawler-tsconfig-paramSets-key-userGroups:
 
          paramSets.[key].userGroups
@@ -183,5 +197,6 @@ Example
       procInstrFilter = tx_indexedsearch_reindex
       pidsOnly = 1,5,13,55
       userGroups = 1
+      force_ssl = 1
    }
 


### PR DESCRIPTION
## Description

This typecasts force_ssl to int PageTS Crawler Configurations.
Resolves #1000 

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
