### PR TITLE
[BUGFIX] Catch E_WARNING when unserialize() fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 * Fixed query building when using _ADDTABLE parameter [@hawkeye1909](https://github.com/hawkeye1909)
 * Typecast PageTS Crawler Configuration `force_ssl` to `int`
+* Catch E_WARNING when unserialize() fails [cweiske](https://github.com/cweiske)
 
 ### Deprecated
 

--- a/Classes/Converter/JsonCompatibilityConverter.php
+++ b/Classes/Converter/JsonCompatibilityConverter.php
@@ -36,7 +36,11 @@ class JsonCompatibilityConverter
      */
     public function convert(string $dataString)
     {
-        $unserialized = unserialize($dataString, ['allowed_classes' => false]);
+        try {
+            $unserialized = unserialize($dataString, ['allowed_classes' => false]);
+        } catch (\Throwable $e) {
+            $unserialized = false;
+        }
         if (is_object($unserialized)) {
             throw new \Exception('Objects are not allowed: ' . var_export($unserialized, true), 1593758307);
         }


### PR DESCRIPTION
Since PHP 8.3, unserialize() throws an E_WARNING instead of E_NOTICE. This leads to an error when viewing crawler information for pages and when crawling sites:

> PHP Warning: unserialize(): Error at offset 0 of 122 bytes
> in typo3conf/ext/crawler/Classes/Converter/JsonCompatibilityConverter.php line 39

This patch solves the problem in the most non-invasive way by simply catching the unserialize warning.

Resolves: https://github.com/tomasnorre/crawler/issues/1087

## Description

<!-- What does this PR do -->

<!-- Does this solve an existing issue, then please reference with #issue-number -->

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
