### PR TITLE
[BUGFIX] Fix showing "Scheduled" and "Run-time" columns in backend log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog TYPO3 Crawler
 
+## Crawler 11.0.12-dev
+
+### Fixed
+* "Scheduled" and "Run-time" column values in backend log [cweiske](https://github.com/cweiske)
+
 ## Crawler 11.0.11
 
 Crawler 11.0.11 was released on January 20th, 2025

--- a/Classes/Backend/RequestForm/LogRequestForm.php
+++ b/Classes/Backend/RequestForm/LogRequestForm.php
@@ -363,7 +363,7 @@ final class LogRequestForm extends AbstractRequestForm implements RequestFormInt
 
                 // Put data into array:
                 $rowData = [];
-                if (isset($this->infoModuleController->MOD_SETTINGS['log_resultLog'])) {
+                if (isset($this->infoModuleController->MOD_SETTINGS['log_resultLog']) && $this->infoModuleController->MOD_SETTINGS['log_resultLog']) {
                     $rowData['result_log'] = $resLog;
                 } else {
                     $rowData['scheduled'] = ($vv['scheduled'] > 0) ? BackendUtility::datetime($vv['scheduled']) : '-';

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -63,7 +63,7 @@ parameters:
 			path: Classes/Backend/RequestForm/LogRequestForm.php
 
 		-
-			message: "#^Class cognitive complexity is 72, keep it under 60$#"
+			message: "#^Class cognitive complexity is 73, keep it under 60$#"
 			count: 1
 			path: Classes/Backend/RequestForm/LogRequestForm.php
 
@@ -762,4 +762,3 @@ parameters:
 			message: "#^Parameter \\#1 \\$row of static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\CsvUtility\\:\\:csvValues\\(\\) expects array\\<string\\>, array\\<int, int\\|string\\> given\\.$#"
 			count: 1
 			path: Classes/Writer/FileWriter/CsvWriter/CrawlerCsvWriter.php
-


### PR DESCRIPTION
In Info > Site Crawler > Crawler log:
As soon as the backend user activated the "Show Result Log" checkbox one time, the columns "Scheduled" and "Run-time" are empty when the checkbox is disabled.

The reason is that the variable's value is not taken into account, only its existence in the user session data.

## Description

<!-- What does this PR do -->

<!-- Does this solve an existing issue, then please reference with #issue-number -->

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
