### PR TITLE
[BUGFIX] Reliably catch E_WARNING when unserialize() fails

### DIFF
--- a/Classes/Converter/JsonCompatibilityConverter.php
+++ b/Classes/Converter/JsonCompatibilityConverter.php
@@ -37,10 +37,16 @@ class JsonCompatibilityConverter
     public function convert(string $dataString)
     {
         try {
+            set_error_handler(function ($severity, $message, $file, $line) {
+                throw new \ErrorException($message, 0, $severity, $file, $line);
+            });
             $unserialized = unserialize($dataString, ['allowed_classes' => false]);
         } catch (\Throwable $e) {
             $unserialized = false;
+        } finally {
+            restore_error_handler();
         }
+
         if (is_object($unserialized)) {
             throw new \Exception('Objects are not allowed: ' . var_export($unserialized, true), 1593758307);
         }


### PR DESCRIPTION
## Description

This PR should reliably catch the E_WARNING by unserialize().
As mentioned in the official [RFC](https://wiki.php.net/rfc/improve_unserialize_error_handling) of the unserialize() change in PHP 8.3, this should be the preferred way of catching this error.

Should resolve #1087.

Sorry to not have checked all the points below, since all mentioned steps in the CONTRIBUTING.md not worked on my local machine.

Tested this code on a project with Typo3 v11.5.41 and PHP 8.3.13.

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
