### PR TITLE
[BUGFIX] Ensure that correct typo3 binary is returned in non-composer installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+* Ensure that correct typo3 binary is returned in non-composer installations
 
 ### Deprecated
 #### Classes

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -162,7 +162,6 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
             $configurationKeys
         );
 
-
         // Consider a swith/match statement here, and extract the code in between.
         if ($mode === 'url') {
             $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->downloadUrls) . PHP_EOL . '</info>');

--- a/Classes/Service/ProcessService.php
+++ b/Classes/Service/ProcessService.php
@@ -92,6 +92,10 @@ class ProcessService
 
     private function getComposerBinPath(): ?string
     {
+        if (!getenv('TYPO3_PATH_COMPOSER_ROOT')) {
+            return sprintf('%s/%s/', getenv('TYPO3_PATH_APP'), 'vendor/typo3/cms-cli');
+        }
+
         // copied and modified from @see
         // https://github.com/TYPO3/typo3/blob/8a9c80b9d85ef986f5f369f1744fc26a6b607dda/typo3/sysext/scheduler/Classes/Controller/SchedulerModuleController.php#L402
         $composerJsonFile = getenv('TYPO3_PATH_COMPOSER_ROOT') . '/composer.json';

--- a/Tests/Functional/Service/ProcessServiceTest.php
+++ b/Tests/Functional/Service/ProcessServiceTest.php
@@ -20,12 +20,10 @@ namespace AOE\Crawler\Tests\Functional\Service;
  */
 
 use AOE\Crawler\Service\ProcessService;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
-/**
- * @package AOE\Crawler\Tests\Unit\Domain\Model
- */
 class ProcessServiceTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = ['typo3conf/ext/crawler'];
@@ -42,7 +40,7 @@ class ProcessServiceTest extends FunctionalTestCase
         $this->subject = GeneralUtility::makeInstance(ProcessService::class);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function getCrawlerCliPathReturnsString(): void
     {
         // Check with phpPath set
@@ -61,5 +59,18 @@ class ProcessServiceTest extends FunctionalTestCase
 
         ];
         self::assertStringContainsString('php', $this->subject->getCrawlerCliPath());
+    }
+
+    #[Test]
+    public function getCrawlerCliPathContainsTYPO3BinaryRespectivelyWithOutComposer(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['crawler'] = [
+            'phpBinary' => 'php',
+
+        ];
+
+        // Unassign TYPO3_PATH_COMPOSER_ROOT
+        putenv('TYPO3_PATH_COMPOSER_ROOT');
+        self::assertStringContainsString('vendor/typo3/cms-cli/typo3', $this->subject->getCrawlerCliPath());
     }
 }


### PR DESCRIPTION
## Description

Resolves #1125, but ensuring that the correct typo3 binary is returned in non-compose installations. 

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
