### PR TITLE
[BUGFIX] Adjust path in cli/bootstrap.php to match new folder structure of where extensions are installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * Ensure that correct typo3 binary is returned in non-composer installations
+* Adjust path in cli/bootstrap.php to match new folder structure of where extensions are installed
 
 ### Deprecated
 #### Classes

--- a/cli/bootstrap.php
+++ b/cli/bootstrap.php
@@ -21,8 +21,7 @@ if (!isAbsPath($tempPathThisScript)) {
     }
 }
 
-$typo3Root = preg_replace('#typo3conf/ext/crawler/cli/bootstrap.php$#', '', $tempPathThisScript);
-
+$typo3Root = preg_replace('#vendor/tomasnorre/crawler/cli/bootstrap.php$#', 'public/', $tempPathThisScript);
 /**
  * Second parameter is a base64 encoded serialized array of header data
  */


### PR DESCRIPTION
## Description

Fixes the path issue in `cli/bootstrap.php` as is don't represent the new folder structure in TYPO3. 

<!-- Does this solve an existing issue, then please reference with #issue-number -->

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
