### PR TITLE
[BUGFIX] Fix indexing of cached pages when "disableFrontendIndexing" …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Adjust path in cli/bootstrap.php to match new folder structure of where extensions are installed
 * Don't wrap empty HTML in table-tag to ensure valid HTML
 * Fix crawling of mount pages
+* Fix indexing of cached pages when "disableFrontendIndexing" is active [@cweiske](https://github.com/cweiske)
 
 ### Deprecated
 #### Classes

--- a/Classes/Domain/Model/Process.php
+++ b/Classes/Domain/Model/Process.php
@@ -182,7 +182,6 @@ class Process extends AbstractEntity
 
     private function getQueueRepository(): QueueRepository
     {
-        $this->queueRepository ??= GeneralUtility::makeInstance(QueueRepository::class);
         return $this->queueRepository;
     }
 }

--- a/Classes/EventListener/ShouldUseCachedPageDataIfAvailableEventListener.php
+++ b/Classes/EventListener/ShouldUseCachedPageDataIfAvailableEventListener.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AOE\Crawler\EventListener;
+
+use TYPO3\CMS\Frontend\Event\ShouldUseCachedPageDataIfAvailableEvent;
+
+/**
+ * Disable frontend cache when the HTTP request has crawler parameters,
+ * so that page indexing hooks are triggered.
+ */
+class ShouldUseCachedPageDataIfAvailableEventListener
+{
+    public function __invoke(ShouldUseCachedPageDataIfAvailableEvent $event): void
+    {
+        if ($event->getRequest()->getAttribute('tx_crawler') === null) {
+            return;
+        }
+        $event->setShouldUseCachedPageData(false);
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -112,3 +112,8 @@ services:
       tags:
         - name: event.listener
           identifier: 'tx-crawler-after-queue-item-added'
+
+    AOE\Crawler\EventListener\ShouldUseCachedPageDataIfAvailableEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'tx-crawler-should-use-cached-page-data-if-available'


### PR DESCRIPTION
…is active

When pages are cached in TYPO3v12, the indexing process is not triggered when crawler fetches the pages.
This becomes a problem when the "Disable Indexing in Frontend" (basic.disableFrontendIndexing) indexed_search flag is enabled, because no indexing is happening then.

The solution is to tell TYPO3 to not use the cache when the page is requested by the crawler process.

See the ShouldUseCachedPageDataIfAvailableEvent documentation at https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-96968-PSR-14EventForAvoidLoadingFrontendPagesFromCache.html

Resolves: https://github.com/tomasnorre/crawler/issues/1029

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
