### PR TITLE
[BUGFIX] Set guzzle connect timeout to 5 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+* Set guzzle connect timeout to 5 seconds [@cweiske](https://github.com/cweiske)
 
 ### Deprecated
 #### Classes

--- a/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
+++ b/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
@@ -48,6 +48,7 @@ class GuzzleExecutionStrategy implements LoggerAwareInterface, CrawlStrategyInte
 
         $options = [
             'headers' => $reqHeaders,
+            'connect_timeout' => 5.0,
         ];
         if ($url->getUserInfo()) {
             $options['auth'] = explode(':', $url->getUserInfo());


### PR DESCRIPTION
## Description
Set guzzle connect timeout to 5 seconds.

Default connect timeout behavior is to wait indefinitely, which means that crawler would hang forever in case the server has problems.

https://docs.guzzlephp.org/en/stable/request-options.html#connect-timeout

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
