### PR TITLE
[FEATURE] Extract error information in SubProcess crawl strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Crawler 12.0.10-dev
 
 ### Added
+* Extract error information in SubProcess crawl strategy [@cweiske](https://github.com/cweiske)
 
 ### Changed
 

--- a/Classes/CrawlStrategy/SubProcessExecutionStrategy.php
+++ b/Classes/CrawlStrategy/SubProcessExecutionStrategy.php
@@ -87,6 +87,24 @@ class SubProcessExecutionStrategy implements LoggerAwareInterface, CrawlStrategy
         if ($content === null) {
             return false;
         }
+        if (str_contains($content, 'typo3-error-page')) {
+            preg_match('#class="typo3-error-page-statuscode">(.+?)</#s', $content, $matchStatus);
+            preg_match('#class="typo3-error-page-title">(.+?)</#s', $content, $matchTitle);
+            preg_match('#class="typo3-error-page-message">(.+?)</#s', $content, $matchMessage);
+            $message = trim($matchStatus[1] ?? '')
+                . ' ' . trim($matchTitle[1] ?? '')
+                . ' - ' . trim($matchMessage[1] ?? '');
+            $this->logger?->debug(
+                sprintf('Error while opening "%s" - %s', $url, $message),
+                [
+                    'crawlerId' => $crawlerId,
+                ]
+            );
+            return [
+                'errorlog' => [$message],
+                'content' => $content,
+            ];
+        }
 
         return [
             'content' => $content,


### PR DESCRIPTION
## Description
Up to now, the sub process execution strategy did not detect errors. The HTML of error pages was provided as content, and the backend showed an "OK" status.

Since cli/bootstrap.php does not set a non-zero exit code on errors, we have to parse the HTML ourselves to detect if an error occured.

This patch supports TYPO3 error pages and extracts HTTP status code, status message and error message from it.

Error informationare logged into the debug log as well as made visible in the backend site crawler log view.

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
