### PR TITLE
[TASK] Fix ddev typo3 upgrade wizard call

### DIFF
--- a/.devbox/.ddev/config.yaml
+++ b/.devbox/.ddev/config.yaml
@@ -23,7 +23,7 @@ hooks:
     - exec: /var/www/html/build-files/import-if-empty.sh
     - exec: /var/www/html/bin/typo3 backend:lock
     - exec: /var/www/html/bin/typo3 extension:setup
-    - exec: /var/www/html/build-files/typo3-uprade-wizard.sh
+    - exec: /var/www/html/build-files/typo3-upgrade-wizard.sh
     - exec: /var/www/html/bin/typo3 cache:flush
     - exec: /var/www/html/bin/typo3 cache:warmup
     - exec: /var/www/html/bin/typo3 backend:unlock


### PR DESCRIPTION
## Description

Typo was introduced in commit
> d4e0cca9edc338ccb5e6e7f23a9a7327a4a7aee6
> feat: add TYPO3 13 support

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
