### PR TITLE
[BUGFIX] Prevent warning when guzzle crawl requests return errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 * Set guzzle connect timeout to 5 seconds [@cweiske](https://github.com/cweiske)
+* Prevent warning when guzzle crawl requests return errors [@cweiske](https://github.com/cweiske)
 
 ### Deprecated
 #### Classes

--- a/Classes/Converter/JsonCompatibilityConverter.php
+++ b/Classes/Converter/JsonCompatibilityConverter.php
@@ -42,27 +42,22 @@ class JsonCompatibilityConverter
         try {
             $decoded = json_decode($dataString, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException) {
-            // Do nothing as we want to continue with unserialize as a test.
+            //no json, fallback to unserialize()
+            try {
+                $decoded = unserialize($dataString, [
+                    'allowed_classes' => false,
+                ]);
+            } catch (\Throwable) {
+                return false;
+            }
         }
 
         if (is_array($decoded)) {
             return $decoded;
         }
 
-        try {
-            $deserialized = unserialize($dataString, [
-                'allowed_classes' => false,
-            ]);
-        } catch (\Throwable) {
-            return false;
-        }
-
-        if (is_object($deserialized)) {
-            throw new \RuntimeException('Objects are not allowed: ' . var_export($deserialized, true), 1_593_758_307);
-        }
-
-        if (is_array($deserialized)) {
-            return $deserialized;
+        if (is_object($decoded)) {
+            throw new \RuntimeException('Objects are not allowed: ' . var_export($decoded, true), 1_593_758_307);
         }
 
         return false;

--- a/Classes/CrawlStrategy/CrawlStrategyInterface.php
+++ b/Classes/CrawlStrategy/CrawlStrategyInterface.php
@@ -26,5 +26,17 @@ use Psr\Http\Message\UriInterface;
  */
 interface CrawlStrategyInterface
 {
+    /**
+     * Fetch the given URL and return its textual response
+     *
+     * @return array|false "false" on errors without explanation.
+     *                     Array may contain the following optional keys:
+     *                     - errorlog: array of string error messages
+     *                     - content: HTML content (string)
+     *                     - running: bool
+     *                     - parameters: array
+     *                     - log: array of strings
+     *                     - vars: array
+     */
     public function fetchUrlContents(UriInterface $url, string $crawlerId);
 }

--- a/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
+++ b/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
@@ -40,7 +40,7 @@ class GuzzleExecutionStrategy implements LoggerAwareInterface, CrawlStrategyInte
     /**
      * Sets up a CURL / Guzzle Request for fetching the request.
      *
-     * @return bool|mixed
+     * @return array|bool|mixed
      */
     public function fetchUrlContents(UriInterface $url, string $crawlerId)
     {
@@ -69,7 +69,9 @@ class GuzzleExecutionStrategy implements LoggerAwareInterface, CrawlStrategyInte
                     'crawlerId' => $crawlerId,
                 ]
             );
-            return $message;
+            return [
+                'errorlog' => [$message],
+            ];
         } catch (ConnectException $e) {
             $message = $e->getCode() . chr(32) . $e->getMessage();
 
@@ -79,7 +81,9 @@ class GuzzleExecutionStrategy implements LoggerAwareInterface, CrawlStrategyInte
                     'crawlerId' => $crawlerId,
                 ]
             );
-            return $message;
+            return [
+                'errorlog' => [$message],
+            ];
         }
     }
 

--- a/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
+++ b/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
@@ -40,7 +40,7 @@ class GuzzleExecutionStrategy implements LoggerAwareInterface, CrawlStrategyInte
     /**
      * Sets up a CURL / Guzzle Request for fetching the request.
      *
-     * @return array|bool|mixed
+     * @return array|false See CrawlStrategyInterface::fetchUrlContents()
      */
     public function fetchUrlContents(UriInterface $url, string $crawlerId)
     {

--- a/Classes/CrawlStrategy/SubProcessExecutionStrategy.php
+++ b/Classes/CrawlStrategy/SubProcessExecutionStrategy.php
@@ -50,7 +50,7 @@ class SubProcessExecutionStrategy implements LoggerAwareInterface, CrawlStrategy
     /**
      * Fetches a URL by calling a shell script.
      *
-     * @return array|bool|mixed
+     * @return array|false See CrawlStrategyInterface::fetchUrlContents()
      */
     public function fetchUrlContents(UriInterface $url, string $crawlerId)
     {

--- a/Classes/QueueExecutor.php
+++ b/Classes/QueueExecutor.php
@@ -49,7 +49,11 @@ class QueueExecutor implements SingletonInterface
      * Takes a queue record and fetches the contents of the URL.
      * In the future, updating the queue item & additional signal/slot/events should also happen in here.
      *
-     * @return array|bool|mixed|string
+     * @return array|false|string Possible return values:
+     *         - "false" for unexplained errors
+     *         - string "ERROR" when queueItem parameters could not be parsed
+     *         - array with single key 'content' that contains the json_encoded crawl results.
+     *           See CrawlStrategyInterface::fetchUrlContents() for its structure.
      */
     public function executeQueueItem(array $queueItem, CrawlerController $crawlerController)
     {

--- a/Tests/Unit/Converter/JsonCompatibilityConverterTest.php
+++ b/Tests/Unit/Converter/JsonCompatibilityConverterTest.php
@@ -60,8 +60,12 @@ class JsonCompatibilityConverterTest extends UnitTestCase
             'dataString' => json_encode($testData),
             'expected' => $testData,
         ];
-        yield 'neither serialize() nor json_encodee' => [
+        yield 'neither serialize() nor json_encode' => [
             'dataString' => 'This is just a plain string',
+            'expected' => false,
+        ];
+        yield 'json false does not trigger unserialize' => [
+            'dataString' => json_encode(false),
             'expected' => false,
         ];
     }

--- a/Tests/Unit/CrawlStrategy/GuzzleExecutionStrategyTest.php
+++ b/Tests/Unit/CrawlStrategy/GuzzleExecutionStrategyTest.php
@@ -81,7 +81,7 @@ class GuzzleExecutionStrategyTest extends UnitTestCase
 
         self::assertStringContainsString(
             'cURL error 6: Could not resolve host: not-important.tld (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)',
-            $guzzleExecutionStrategy->fetchUrlContents($url, $crawlerId)
+            $guzzleExecutionStrategy->fetchUrlContents($url, $crawlerId)['errorlog'][0]
         );
     }
 }

--- a/Tests/Unit/Domain/Model/ProcessTest.php
+++ b/Tests/Unit/Domain/Model/ProcessTest.php
@@ -100,8 +100,8 @@ class ProcessTest extends UnitTestCase
     {
         /** @var MockObject|Process $processMock */
         $processMock = self::getAccessibleMock(Process::class, ['isActive', 'getProgress'], [], '', false);
-        $processMock->expects($this->any())->method('isActive')->will($this->returnValue((bool) $active));
-        $processMock->expects($this->any())->method('getProgress')->will($this->returnValue($processes));
+        $processMock->expects($this->any())->method('isActive')->willReturn((bool) $active);
+        $processMock->expects($this->any())->method('getProgress')->willReturn((float) $processes);
 
         self::assertEquals($expectedState, $processMock->getState());
     }
@@ -121,12 +121,8 @@ class ProcessTest extends UnitTestCase
             '',
             false
         );
-        $processMock->expects($this->any())->method('getAssignedItemsCount')->will(
-            $this->returnValue($countItemsAssigned)
-        );
-        $processMock->expects($this->any())->method('getAmountOfItemsProcessed')->will(
-            $this->returnValue($countItemsProcessed)
-        );
+        $processMock->expects($this->any())->method('getAssignedItemsCount')->willReturn($countItemsAssigned);
+        $processMock->expects($this->any())->method('getAmountOfItemsProcessed')->willReturn($countItemsProcessed);
 
         self::assertEquals($expectedProgress, $processMock->getProgress());
     }
@@ -202,11 +198,11 @@ class ProcessTest extends UnitTestCase
             '',
             false
         );
-        $queueRepositoryMock->expects($this->any())->method('findOldestEntryForProcess')->will(
-            $this->returnValue($getTimeForLastItem)
+        $queueRepositoryMock->expects($this->any())->method('findOldestEntryForProcess')->willReturn(
+            $getTimeForLastItem
         );
-        $queueRepositoryMock->expects($this->any())->method('findYoungestEntryForProcess')->will(
-            $this->returnValue($getTimeForFirstItem)
+        $queueRepositoryMock->expects($this->any())->method('findYoungestEntryForProcess')->willReturn(
+            $getTimeForFirstItem
         );
 
         $this->subject->_setProperty('queueRepository', $queueRepositoryMock);

--- a/Tests/Unit/Service/ProcessServiceTest.php
+++ b/Tests/Unit/Service/ProcessServiceTest.php
@@ -44,7 +44,7 @@ class ProcessServiceTest extends UnitTestCase
         $mockedProcessRepository
             ->expects($this->exactly(2))
             ->method('countNotTimeouted')
-            ->will($this->onConsecutiveCalls(1, 2));
+            ->willReturn(1, 2);
 
         $processService = $this->getAccessibleMock(
             ProcessService::class,
@@ -69,7 +69,7 @@ class ProcessServiceTest extends UnitTestCase
         $mockedProcessRepository
             ->expects($this->exactly(11))
             ->method('countNotTimeouted')
-            ->will($this->onConsecutiveCalls(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
+            ->willReturn(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
 
         $processService = $this->getAccessibleMock(
             ProcessService::class,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -205,12 +205,6 @@ parameters:
 			path: Classes/CrawlStrategy/CrawlStrategyFactory.php
 
 		-
-			message: '#^Method AOE\\Crawler\\CrawlStrategy\\CrawlStrategyInterface\:\:fetchUrlContents\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: Classes/CrawlStrategy/CrawlStrategyInterface.php
-
-		-
 			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1


### PR DESCRIPTION
## Description
Let the guzzle crawl strategy return errors in the same way that the subprocess strategy does: As array inside an 'errorlog' array.

Also rework the logic that JsonCompatibilityConverter uses to decide when to `unserialize()`.
And fix some phpunit deprecations, and document the crawl strategy return value structure.

Resolves: https://github.com/tomasnorre/crawler/issues/1166

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
