### PR TITLE
[FEATURE] Expose error when crawl response has no X-T3Crawler-Meta header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * Extract error information in SubProcess crawl strategy [@cweiske](https://github.com/cweiske)
+* Expose error when crawl response has not X-T3Crawler-Meta header [@cweiske](https://github.com/cweiske)
 
 ### Changed
 

--- a/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
+++ b/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
@@ -56,7 +56,15 @@ class GuzzleExecutionStrategy implements LoggerAwareInterface, CrawlStrategyInte
         try {
             $url = (string) $url;
             $response = $this->getResponse($url, $options);
-            return unserialize($response->getHeaderLine('X-T3Crawler-Meta'));
+            if ($response->hasHeader('X-T3Crawler-Meta')) {
+                return unserialize($response->getHeaderLine('X-T3Crawler-Meta'));
+            }
+            return [
+                'errorlog' => ['Response has no X-T3Crawler-Meta header'],
+                'vars' => [
+                    'status' => $response->getStatusCode() . ' ' . $response->getReasonPhrase(),
+                ],
+            ];
         } catch (RequestException $e) {
             $response = $e->getResponse();
             $message = ($response ? $response->getStatusCode() : 0)

--- a/Classes/Service/UrlService.php
+++ b/Classes/Service/UrlService.php
@@ -123,9 +123,9 @@ class UrlService
         foreach ($urls as $url) {
             foreach ($valueSet as $val) {
                 if (count($newUrls) < $maxUrlToCompile) {
-                    $newUrls[] = $url . (strcmp((string) $val, '') ? '&' . rawurlencode($varName) . '=' . rawurlencode(
-                        (string) $val
-                    ) : '');
+                    $newUrls[] = $url . (strcmp((string) $val, '') ? '&' . rawurlencode(
+                        (string) $varName
+                    ) . '=' . rawurlencode((string) $val) : '');
                 }
             }
         }

--- a/Documentation/Troubleshooting/Index.rst
+++ b/Documentation/Troubleshooting/Index.rst
@@ -180,3 +180,13 @@ Workaround
 this problem isn't solved, but it can be bypassed by using the `helhum/dotenv-connector`
 https://github.com/helhum/dotenv-connector
 
+
+.. _troubleshooting-header
+
+X-T3Crawler-Meta header missing
+===============================
+When the crawler log reports "Response has no X-T3Crawler-Meta header",
+then a firewall probably filters incoming or outgoing HTTP headers.
+
+Crawler sends a `X-T3Crawler` header to TYPO3 and expects a `X-T3Crawler-Meta`
+in the response. If those are removed in transit, crawler will not work.


### PR DESCRIPTION
## Description
When the web server filters incoming and outgoing HTTP headers, the `X-T3Crawler-Meta` header (needed to transport crawler information back from indexing) may also get filtered away.

This patch lets crawler detect that problem and show it in the backend process log.

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
