### PR TITLE
[TASK] Refactor JsonCompatibilityConverter, change return type to always arrays

### DIFF
--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -218,7 +218,7 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
 
         foreach ($progressBar->iterate($this->crawlerController->queueEntries) as $queueRec) {
             $p = $this->jsonCompatibilityConverter->convert($queueRec['parameters']);
-            if (is_bool($p)) {
+            if (empty($p)) {
                 continue;
             }
 
@@ -237,7 +237,7 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
             $requestResult = $this->jsonCompatibilityConverter->convert($resultContent);
 
             $progressBar->clear();
-            if (is_array($requestResult)) {
+            if (!empty($requestResult)) {
                 $resLog = array_key_exists('log', $requestResult)
                 && is_array($requestResult['log']) ? chr(9) . chr(9) .
                     implode(PHP_EOL . chr(9) . chr(9), $requestResult['log']) : '';

--- a/Classes/Controller/Backend/BackendModuleCrawlerLogController.php
+++ b/Classes/Controller/Backend/BackendModuleCrawlerLogController.php
@@ -117,14 +117,12 @@ final class BackendModuleCrawlerLogController extends AbstractBackendModuleContr
         $q_entry['parameters'] = $this->jsonCompatibilityConverter->convert($q_entry['parameters']);
         $q_entry['result_data'] = $this->jsonCompatibilityConverter->convert($q_entry['result_data']);
         $resStatus = ResultHandler::getResStatus($q_entry['result_data']);
-        if (is_array($q_entry['result_data'])) {
+        if (!empty($q_entry['result_data'])) {
             $q_entry['result_data']['content'] = $this->jsonCompatibilityConverter->convert(
                 $q_entry['result_data']['content']
             );
             if (!$this->showResultLog) {
-                if (is_array($q_entry['result_data']['content'])) {
-                    unset($q_entry['result_data']['content']['log']);
-                }
+                unset($q_entry['result_data']['content']['log']);
             }
         }
         return [$q_entry, $resStatus];

--- a/Classes/Controller/Backend/Helper/ResultHandler.php
+++ b/Classes/Controller/Backend/Helper/ResultHandler.php
@@ -35,12 +35,12 @@ class ResultHandler
         $content = '';
         if (is_array($resultRow) && array_key_exists('result_data', $resultRow)) {
             $requestContent = self::getJsonCompatibilityConverter()->convert($resultRow['result_data']) ?: [];
-            if (is_bool($requestContent) || !array_key_exists('content', $requestContent)) {
+            if (!array_key_exists('content', $requestContent)) {
                 return $content;
             }
             $requestResult = self::getJsonCompatibilityConverter()->convert($requestContent['content']);
 
-            if (is_array($requestResult) && array_key_exists('log', $requestResult)) {
+            if (array_key_exists('log', $requestResult)) {
                 $content = implode(chr(10), $requestResult['log']);
             }
         }
@@ -57,7 +57,7 @@ class ResultHandler
         }
 
         $requestResult = self::getJsonCompatibilityConverter()->convert($requestContent['content']);
-        if (is_array($requestResult)) {
+        if (!empty($requestResult)) {
             if (empty($requestResult['errorlog'])) {
                 return 'OK';
             }
@@ -76,7 +76,7 @@ class ResultHandler
             return [];
         }
         $requestResult = self::getJsonCompatibilityConverter()->convert($resultData['content']);
-        if (is_bool($requestResult)) {
+        if (empty($requestResult)) {
             return [];
         }
         return $requestResult['vars'] ?? [];

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -584,7 +584,7 @@ class CrawlerController implements LoggerAwareInterface
 
             //atm there's no need to point to specific pollable extensions
             if (
-                is_array($resultData)
+                !empty($resultData)
                 && isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['crawler']['pollSuccess'])
                 && is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['crawler']['pollSuccess'])
             ) {

--- a/Classes/Converter/JsonCompatibilityConverter.php
+++ b/Classes/Converter/JsonCompatibilityConverter.php
@@ -36,7 +36,7 @@ class JsonCompatibilityConverter
      *
      * @throws Exception
      */
-    public function convert(string $dataString): array|bool
+    public function convert(string $dataString): array
     {
         $decoded = '';
         try {
@@ -48,7 +48,7 @@ class JsonCompatibilityConverter
                     'allowed_classes' => false,
                 ]);
             } catch (\Throwable) {
-                return false;
+                return [];
             }
         }
 
@@ -60,6 +60,6 @@ class JsonCompatibilityConverter
             throw new \RuntimeException('Objects are not allowed: ' . var_export($decoded, true), 1_593_758_307);
         }
 
-        return false;
+        return [];
     }
 }

--- a/Classes/Middleware/FrontendUserAuthenticator.php
+++ b/Classes/Middleware/FrontendUserAuthenticator.php
@@ -81,19 +81,17 @@ class FrontendUserAuthenticator implements MiddlewareInterface
         $request = $request->withAttribute('tx_crawler', $queueParameters);
 
         // Now ensure to set the proper user groups
-        if (is_array($queueParameters)) {
-            $grList = $queueParameters['feUserGroupList'] ?? '';
-            if ($grList) {
-                $frontendUser = $this->getFrontendUser($grList, $request);
+        $grList = $queueParameters['feUserGroupList'] ?? '';
+        if ($grList) {
+            $frontendUser = $this->getFrontendUser($grList, $request);
 
-                // we have to set the fe user group to the user aspect since indexed_search only reads the user aspect
-                // to get the groups. otherwise groups are ignored during indexing.
-                // we need to add the groups 0, and -2 too, like the getGroupIds getter does.
-                $this->context->setAspect(
-                    'frontend.user',
-                    GeneralUtility::makeInstance(UserAspect::class, $frontendUser, explode(',', '0,-2,' . $grList))
-                );
-            }
+            // we have to set the fe user group to the user aspect since indexed_search only reads the user aspect
+            // to get the groups. otherwise groups are ignored during indexing.
+            // we need to add the groups 0, and -2 too, like the getGroupIds getter does.
+            $this->context->setAspect(
+                'frontend.user',
+                GeneralUtility::makeInstance(UserAspect::class, $frontendUser, explode(',', '0,-2,' . $grList))
+            );
         }
 
         return $handler->handle($request);

--- a/Tests/Unit/Converter/JsonCompatibilityConverterTest.php
+++ b/Tests/Unit/Converter/JsonCompatibilityConverterTest.php
@@ -62,11 +62,11 @@ class JsonCompatibilityConverterTest extends UnitTestCase
         ];
         yield 'neither serialize() nor json_encode' => [
             'dataString' => 'This is just a plain string',
-            'expected' => false,
+            'expected' => [],
         ];
         yield 'json false does not trigger unserialize' => [
             'dataString' => json_encode(false),
-            'expected' => false,
+            'expected' => [],
         ];
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -243,8 +243,7 @@ parameters:
 			count: 1
 			path: Classes/Event/ModifySkipPageEvent.php
 
-		
-    -
+        -
 			message: '#^Method AOE\\Crawler\\Service\\BackendModuleLogService\:\:addRows\(\) should return non\-empty\-list\<array\{titleRowSpan\: int\<1, max\>, colSpan\: int, title\: string, noEntries\?\: string, trClass\?\: string, qid\?\: array\{link\: TYPO3\\CMS\\Core\\Http\\Uri, link\-text\: string\}, refresh\?\: array\{link\: TYPO3\\CMS\\Core\\Http\\Uri, link\-text\: TYPO3\\CMS\\Core\\Imaging\\Icon, warning\: string\|TYPO3\\CMS\\Core\\Imaging\\Icon\}, columns\?\: array\{url\: mixed, scheduled\: string, exec_time\: string, result_log\: string, result_status\: string, feUserGroupList\: string, procInstructions\: string, set_id\: string, \.\.\.\}\}\> but returns array\{non\-empty\-list\<array\>, array\}\.$#'
 			identifier: return.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -243,7 +243,7 @@ parameters:
 			count: 1
 			path: Classes/Event/ModifySkipPageEvent.php
 
-        -
+		-
 			message: '#^Method AOE\\Crawler\\Service\\BackendModuleLogService\:\:addRows\(\) should return non\-empty\-list\<array\{titleRowSpan\: int\<1, max\>, colSpan\: int, title\: string, noEntries\?\: string, trClass\?\: string, qid\?\: array\{link\: TYPO3\\CMS\\Core\\Http\\Uri, link\-text\: string\}, refresh\?\: array\{link\: TYPO3\\CMS\\Core\\Http\\Uri, link\-text\: TYPO3\\CMS\\Core\\Imaging\\Icon, warning\: string\|TYPO3\\CMS\\Core\\Imaging\\Icon\}, columns\?\: array\{url\: mixed, scheduled\: string, exec_time\: string, result_log\: string, result_status\: string, feUserGroupList\: string, procInstructions\: string, set_id\: string, \.\.\.\}\}\> but returns array\{non\-empty\-list\<array\>, array\}\.$#'
 			identifier: return.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -262,18 +262,6 @@ parameters:
 			path: Classes/Middleware/FrontendUserAuthenticator.php
 
 		-
-			message: '#^Cannot access offset ''alturl'' on array\|bool\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: Classes/Service/BackendModuleLogService.php
-
-		-
-			message: '#^Cannot access offset ''procInstructions'' on array\|bool\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: Classes/Service/BackendModuleLogService.php
-
-		-
 			message: '#^Method AOE\\Crawler\\Service\\BackendModuleLogService\:\:addRows\(\) should return non\-empty\-list\<array\{titleRowSpan\: int\<1, max\>, colSpan\: int, title\: string, noEntries\?\: string, trClass\?\: string, qid\?\: array\{link\: TYPO3\\CMS\\Core\\Http\\Uri, link\-text\: string\}, refresh\?\: array\{link\: TYPO3\\CMS\\Core\\Http\\Uri, link\-text\: TYPO3\\CMS\\Core\\Imaging\\Icon, warning\: string\|TYPO3\\CMS\\Core\\Imaging\\Icon\}, columns\?\: array\{url\: mixed, scheduled\: string, exec_time\: string, result_log\: string, result_status\: string, feUserGroupList\: string, procInstructions\: string, set_id\: string, \.\.\.\}\}\> but returns array\{non\-empty\-list\<array\>, array\}\.$#'
 			identifier: return.type
 			count: 1


### PR DESCRIPTION
## Description

This is a refactoring only have one return type for the JsonCompatibilityConverter, so that it's always return arrays, but an empty array on errors, that earlier was false.

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
