### PR TITLE
Declare parameter explicitly nullable

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -33,7 +33,7 @@ class PageService
 {
     private readonly EventDispatcher $eventDispatcher;
 
-    public function __construct(EventDispatcher $eventDispatcher = null)
+    public function __construct(?EventDispatcher $eventDispatcher = null)
     {
         $this->eventDispatcher = $eventDispatcher ?? GeneralUtility::makeInstance(EventDispatcher::class);
     }


### PR DESCRIPTION
Implicitly marking parameter `$eventDispatcher` as nullable is deprecated. Now the explicit nullable type has been used instead.