### PR TITLE
[TASK] Remove Dependecy for typo3-cms/seo and only enable logic when present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 * Updated symfony-components dependencies to ^7.2
 * Updated PHPUnit to ^11.5
-* sitemap_priority is no longer added from crawler, only when typo3-cms/seo is installed
+* sitemap_priority is no longer added from crawler, only when typo3-cms/seo is installed [@tomasnorre](https://github.com/tomasnorre)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 * Updated symfony-components dependencies to ^7.2
 * Updated PHPUnit to ^11.5
+* sitemap_priority is no longer added from crawler, only when typo3-cms/seo is installed
 
 ### Fixed
 

--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -29,6 +29,7 @@ use Psr\Log\LoggerAwareTrait;
 use Symfony\Contracts\Service\Attribute\Required;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -295,28 +296,39 @@ class QueueRepository implements LoggerAwareInterface
 
     public function fetchRecordsToBeCrawled(int $countInARun): array
     {
-        $queryBuilderSelect = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(
             self::TABLE_NAME
         );
-        return $queryBuilderSelect
-            ->select('qid', 'scheduled', 'page_id', 'sitemap_priority')
+
+        $isSeoEnabled = ExtensionManagementUtility::isLoaded('seo');
+        $fields = ['qid', 'scheduled', 'page_id'];
+        if ($isSeoEnabled) {
+            $fields[] = 'sitemap_priority';
+        }
+
+        $queryBuilder
+            ->select(...$fields)
             ->from(self::TABLE_NAME)
             ->leftJoin(
                 self::TABLE_NAME,
                 'pages',
                 'p',
-                $queryBuilderSelect->expr()->eq(
-                    'p.uid',
-                    $queryBuilderSelect->quoteIdentifier(self::TABLE_NAME . '.page_id')
-                )
+                $queryBuilder->expr()->eq('p.uid', $queryBuilder->quoteIdentifier(self::TABLE_NAME . '.page_id'))
             )
             ->where(
-                $queryBuilderSelect->expr()->eq('exec_time', 0),
-                $queryBuilderSelect->expr()->eq('process_scheduled', 0),
-                $queryBuilderSelect->expr()->lte('scheduled', time())
-            )
-            ->orderBy('sitemap_priority', 'DESC')
-            ->addOrderBy('scheduled')
+                $queryBuilder->expr()->eq('exec_time', 0),
+                $queryBuilder->expr()->eq('process_scheduled', 0),
+                $queryBuilder->expr()->lte('scheduled', time())
+            );
+
+        if ($isSeoEnabled) {
+            $queryBuilder->orderBy('sitemap_priority', 'DESC');
+            $queryBuilder->addOrderBy('scheduled');
+        } else {
+            $queryBuilder->orderBy('scheduled');
+        }
+
+        return $queryBuilder
             ->addOrderBy('qid')
             ->setMaxResults($countInARun)
             ->executeQuery()

--- a/Tests/Functional/Command/BuildQueueCommandTest.php
+++ b/Tests/Functional/Command/BuildQueueCommandTest.php
@@ -67,6 +67,8 @@ class BuildQueueCommandTest extends FunctionalTestCase
         ],
     ];
 
+    protected array $coreExtensionsToLoad = ['seo'];
+
     protected array $testExtensionsToLoad = ['typo3conf/ext/crawler'];
 
     protected QueueRepository $queueRepository;

--- a/Tests/Functional/Command/ProcessQueueCommandTest.php
+++ b/Tests/Functional/Command/ProcessQueueCommandTest.php
@@ -31,6 +31,8 @@ class ProcessQueueCommandTest extends FunctionalTestCase
 {
     use BackendRequestTestTrait;
 
+    protected array $coreExtensionsToLoad = ['seo'];
+
     protected array $testExtensionsToLoad = ['typo3conf/ext/crawler'];
 
     protected CommandTester $commandTester;

--- a/Tests/Functional/Controller/CrawlerControllerTest.php
+++ b/Tests/Functional/Controller/CrawlerControllerTest.php
@@ -36,6 +36,8 @@ class CrawlerControllerTest extends FunctionalTestCase
 {
     use BackendRequestTestTrait;
 
+    protected array $coreExtensionsToLoad = ['seo'];
+
     protected array $testExtensionsToLoad = ['typo3conf/ext/crawler'];
 
     protected AccessibleObjectInterface|MockObject $subject;

--- a/Tests/Functional/Domain/Repository/ConfigurationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/ConfigurationRepositoryTest.php
@@ -27,6 +27,8 @@ class ConfigurationRepositoryTest extends FunctionalTestCase
 {
     private const PAGE_WITHOUT_CONFIGURATIONS = 11;
 
+    protected array $coreExtensionsToLoad = ['seo'];
+
     protected array $testExtensionsToLoad = ['typo3conf/ext/crawler'];
 
     protected \AOE\Crawler\Domain\Repository\ConfigurationRepository $subject;

--- a/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
@@ -36,6 +36,8 @@ class QueueRepositoryTest extends FunctionalTestCase
 {
     use BackendRequestTestTrait;
 
+    protected array $coreExtensionsToLoad = ['seo'];
+
     protected array $testExtensionsToLoad = ['typo3conf/ext/crawler'];
 
     protected \AOE\Crawler\Domain\Repository\QueueRepository $subject;

--- a/Tests/Functional/Service/ConfigurationServiceTest.php
+++ b/Tests/Functional/Service/ConfigurationServiceTest.php
@@ -32,6 +32,8 @@ class ConfigurationServiceTest extends FunctionalTestCase
 {
     use ProphecyTrait;
 
+    protected array $coreExtensionsToLoad = ['seo'];
+
     protected array $testExtensionsToLoad = ['typo3conf/ext/crawler'];
     private ConfigurationService $subject;
 

--- a/Tests/Unit/Helper/Sleeper/SystemSleeperTest.php
+++ b/Tests/Unit/Helper/Sleeper/SystemSleeperTest.php
@@ -27,6 +27,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 #[CoversClass(SystemSleeper::class)]
 class SystemSleeperTest extends UnitTestCase
 {
+    protected bool $resetSingletonInstances = true;
+
     #[Test]
     public function sleepSleeps(): void
     {

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,7 @@
         "typo3/cms-core": "^13.4 || ^14.1",
         "typo3/cms-extbase": "^13.4 || ^14.1",
         "typo3/cms-frontend": "^13.4 || ^14.1",
-        "typo3/cms-info": "^13.4 || ^14.1",
-        "typo3/cms-seo": "^13.4 || ^14.1"
+        "typo3/cms-info": "^13.4 || ^14.1"
     },
     "require-dev": {
         "infection/infection": "^0.29.9",
@@ -56,6 +55,7 @@
         "tomasvotruba/cognitive-complexity": "^1.0",
         "tomasvotruba/type-coverage": "^2.0",
         "typo3/testing-framework": "^9.3",
+        "typo3/cms-seo": "^13.4 || ^14.1",
         "vimeo/psalm": "^6.13"
     },
     "replace": {
@@ -66,7 +66,7 @@
         "symfony/dependency-injection": "7.4.0"
     },
     "suggest": {
-        "typo3/cms-seo": "Enables the posibility to priorities your Crawler Queue + You have seo features in the CMS it self."
+        "typo3/cms-seo": "Enables the possibility to priorities your Crawler Queue + You have seo features in the CMS it self."
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -61,14 +61,3 @@ CREATE TABLE tx_crawler_configuration
     exclude                              text                     NOT NULL
 
 ) ENGINE=InnoDB;
-
-#
-# Table structure for table 'pages'
-# This is added to reuse the information from typo3/cms-seo.
-# As we don't have a dependency for typo3/cms-seo it's added here to ensure that the
-# database queries isn't breaking
-#
-CREATE TABLE pages
-(
-    sitemap_priority decimal(2, 1) DEFAULT '0.5' NOT NULL
-);


### PR DESCRIPTION
## Description

Removes logic from typo3-cms/seo to only be included if extension is loaded. There is no fallback anymore if not loaded.

Resolves #1202 

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
